### PR TITLE
Fix metadata

### DIFF
--- a/URREF.ttl
+++ b/URREF.ttl
@@ -58,21 +58,24 @@ Technologies for Uncertainty Representation Working Group
 #################################################################
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DerivationOfUncertainty
-:DerivationOfUncertainty a owl:ObjectProperty ;
+:DerivationOfUncertainty a owl:ObjectProperty ,
+                           owl:FunctionalProperty ;
+                         rdfs:label "Derivation Of Uncertainty" ;
                          rdfs:subPropertyOf owl:topObjectProperty ;
-                         a owl:FunctionalProperty ;
                          rdfs:domain :Evidence ;
                          rdfs:range :UncertaintyDerivation .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#GivesDataInputTo
 :GivesDataInputTo a owl:ObjectProperty ;
+                  rdfs:label "Gives Data Input To" ;
                   rdfs:subPropertyOf owl:topObjectProperty ;
                   rdfs:domain :Source .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasEvaluationSubject
 :HasEvaluationSubject a owl:ObjectProperty ;
+                      rdfs:label "Has Evaluation Subject" ;
                       rdfs:subPropertyOf owl:topObjectProperty ;
                       owl:inverseOf :IsSubjectOfEvaluationIn ;
                       rdfs:domain :EvaluationProcess ;
@@ -84,6 +87,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasImperfection
 :HasImperfection a owl:ObjectProperty ;
+                 rdfs:label "Has Imperfection" ;
                  rdfs:subPropertyOf owl:topObjectProperty ;
                  rdfs:domain :Evidence ;
                  rdfs:range :UncertaintyType .
@@ -91,6 +95,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasSource
 :HasSource a owl:ObjectProperty ;
+           rdfs:label "Has Source" ;
            rdfs:subPropertyOf owl:topObjectProperty ;
            rdfs:domain :DataInput ,
                        :Evidence ;
@@ -99,7 +104,8 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasUncertaintySupport
 :HasUncertaintySupport a owl:ObjectProperty ,
-                                owl:FunctionalProperty ;
+                         owl:FunctionalProperty ;
+                       rdfs:label "Has Uncertainty Support" ;
                        rdfs:subPropertyOf owl:topObjectProperty ;
                        rdfs:domain :Evidence ;
                        rdfs:range :UncertaintySupport .
@@ -107,6 +113,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#IsSubjectOfEvaluationIn
 :IsSubjectOfEvaluationIn a owl:ObjectProperty ;
+                         rdfs:label "Is Subject Of Evaluation In" ;
                          rdfs:subPropertyOf owl:topObjectProperty ;
                          rdfs:domain :FusionSystem ,
                                      :Information ,
@@ -117,7 +124,8 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#NatureOfUncertainty
 :NatureOfUncertainty a owl:ObjectProperty ,
-                              owl:FunctionalProperty ;
+                       owl:FunctionalProperty ;
+                     rdfs:label "Nature Of Uncertainty" ;
                      rdfs:subPropertyOf owl:topObjectProperty ;
                      rdfs:domain :Evidence ;
                      rdfs:range :UncertaintyNature .
@@ -125,6 +133,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#OuputAssessedBy
 :OuputAssessedBy a owl:ObjectProperty ;
+                 rdfs:label "Ouput Assessed By" ;
                  rdfs:subPropertyOf owl:topObjectProperty ;
                  owl:inverseOf :QualityAssesses ;
                  rdfs:domain :DataOutput ;
@@ -133,6 +142,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#QualityAssesses
 :QualityAssesses a owl:ObjectProperty ;
+                 rdfs:label "Quality Assesses" ;
                  rdfs:subPropertyOf owl:topObjectProperty ;
                  rdfs:domain :Quality ;
                  rdfs:range :DataOutput .
@@ -140,6 +150,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ReadSource
 :ReadSource a owl:ObjectProperty ;
+            rdfs:label "Read Source" ;
             rdfs:subPropertyOf owl:topObjectProperty ;
             rdfs:domain :DataProcessingTechnique ;
             rdfs:range :Source .
@@ -147,6 +158,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesTo
 :appliesTo a owl:ObjectProperty ;
+           rdfs:label "Applies To" ;
            rdfs:subPropertyOf owl:topObjectProperty ;
            rdfs:domain :UncertaintyRepresentation ;
            rdfs:range :RepresentationCriterion ;
@@ -156,6 +168,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesToHandling
 :appliesToHandling a owl:ObjectProperty ;
+                   rdfs:label "Applies To Handling" ;
                    rdfs:subPropertyOf :appliesTo ;
                    rdfs:domain :InformationHandlingMethod ;
                    rdfs:range :InformationHandlingCriterion ;
@@ -165,6 +178,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesToReasoning
 :appliesToReasoning a owl:ObjectProperty ;
+                    rdfs:label "Applies To Reasoning" ;
                     rdfs:subPropertyOf :appliesTo ;
                     rdfs:domain :UncertaintyReasoning ;
                     rdfs:range :ReasoningCriterion ;
@@ -174,6 +188,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesToRepresentation
 :appliesToRepresentation a owl:ObjectProperty ;
+                         rdfs:label "Applies To Representation" ;
                          rdfs:subPropertyOf :appliesTo ;
                          rdfs:domain :UncertaintyRepresentation ;
                          rdfs:range :RepresentationCriterion ;
@@ -183,6 +198,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#assesses
 :assesses a owl:ObjectProperty ;
+          rdfs:label "Assesses" ;
           rdfs:subPropertyOf owl:topObjectProperty ;
           owl:inverseOf :isAssessedBy ;
           rdfs:domain :Credibility ;
@@ -191,6 +207,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#basedOn
 :basedOn a owl:ObjectProperty ;
+         rdfs:label "Based On" ;
          rdfs:subPropertyOf owl:topObjectProperty ;
          rdfs:domain :InformationHandlingMethod,
                      :UncertaintyReasoning,
@@ -202,6 +219,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#employs
 :employs a owl:ObjectProperty ;
+         rdfs:label "Employs" ;
          rdfs:subPropertyOf owl:topObjectProperty ;
          rdfs:domain :EvaluationMeasure ;
          rdfs:range :EvaluationProcess ;
@@ -211,6 +229,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#hasInformation
 :hasInformation a owl:ObjectProperty ;
+                rdfs:label "Has Information" ;
                 rdfs:subPropertyOf owl:topObjectProperty ;
                 rdfs:domain :DataInput ,
                             :Source .
@@ -218,6 +237,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#impacts
 :impacts a owl:ObjectProperty ;
+         rdfs:label "Impacts" ;
          rdfs:subPropertyOf owl:topObjectProperty ;
          rdfs:domain :InformationCriterion,
                      :SourceCriterion ;
@@ -228,6 +248,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#isAssessedBy
 :isAssessedBy a owl:ObjectProperty ;
+              rdfs:label "Is Assessed By" ;
               rdfs:subPropertyOf owl:topObjectProperty ;
               rdfs:domain :DataInput ;
               rdfs:range :Credibility .
@@ -235,6 +256,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#measures
 :measures a owl:ObjectProperty ;
+          rdfs:label "Measures" ;
           rdfs:subPropertyOf owl:topObjectProperty ;
           rdfs:domain :EvaluationMeasure ;
           rdfs:range :EvaluationCriterion ;
@@ -248,6 +270,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasPieceOfInformation
 :HasPieceOfInformation a owl:DatatypeProperty ;
+                       rdfs:label "Has Piece Of Information" ;
                        rdfs:subPropertyOf owl:topDataProperty ;
                        rdfs:domain :Evidence ;
                        rdfs:range xsd:string .
@@ -255,6 +278,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasUncertanitySupport
 :HasUncertanitySupport a owl:DatatypeProperty ;
+                       rdfs:label "Has Uncertanity Support" ;
                        rdfs:subPropertyOf owl:topDataProperty ;
                        rdfs:domain :Evidence ;
                        rdfs:range xsd:string .
@@ -262,6 +286,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#TypeOfInformation
 :TypeOfInformation a owl:DatatypeProperty ;
+                   rdfs:label "Type Of Information" ;
                    rdfs:subPropertyOf owl:topDataProperty ;
                    rdfs:domain :Evidence ;
                    rdfs:range xsd:string .
@@ -269,12 +294,14 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#hasCode
 :hasCode a owl:DatatypeProperty ,
-                  owl:FunctionalProperty ;
+           owl:FunctionalProperty ;
+         rdfs:label "Has Code" ;
          rdfs:subPropertyOf owl:topDataProperty .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#usesource
 :usesource a owl:DatatypeProperty ;
+           rdfs:label "Use Source" ;
            rdfs:subPropertyOf owl:topDataProperty .
 
 
@@ -284,34 +311,40 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Accuracy
 :Accuracy a owl:Class ;
+          rdfs:label "Accuracy" ;
           rdfs:subClassOf :Quality ;
           rdfs:isDefinedBy "Closeness of agreement between an evaluation subject value and the true value of the quantity or quality being evaluated." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Adaptability
 :Adaptability a owl:Class ;
+              rdfs:label "Adaptability" ;
               rdfs:subClassOf :RepresentationCriterion ;
               rdfs:isDefinedBy "Ability of the representational model to allow for different configurations of the model. " .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Aleatory
 :Aleatory a owl:Class ;
+          rdfs:label "Aleatory" ;
           rdfs:subClassOf :UncertaintyNature .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#AmbiguousEvidence
 :AmbiguousEvidence a owl:Class ;
+                   rdfs:label "Ambiguous Evidence" ;
                    rdfs:subClassOf :UncertainEvidence .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Assessment
 :Assessment a owl:Class ;
+            rdfs:label "Assessment" ;
             rdfs:subClassOf :Expressiveness ;
             rdfs:isDefinedBy "Measure of the ability of the system to handle the types of uncertainty assessments (e.g., verbal, quantitative, combined) needed for a given problem, and to distinguish them from one another. " .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Availability
 :Availability a owl:Class ;
+              rdfs:label "Availability" ;
               rdfs:subClassOf :InformationHandlingCriterion ;
               rdfs:isDefinedBy "TODO" ;
               owl:versionInfo "4.0.0" .
@@ -319,12 +352,14 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#BeliefFunctions
 :BeliefFunctions a owl:Class ;
+                 rdfs:label "Belief Functions" ;
                  rdfs:subClassOf :UncertaintyTheory ;
                  rdfs:comment "Belief functions are closely related to probabilities. Beliefs in a hypothesis is calculated as the sum of the masses of all sets it encloses. A belief function differs from a Bayesian probability model in that one does not condition on those parts of the evidence for which no probabilities are specified. This ability to explicitly model the degree of ignorance makes the theory very appealing and has been applied in areas such as inconsistency handling in OWL ontologies (Nikolov et al., 2007) and ontology mapping (e.g. Yaghlane and Laamari, 2007)."@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#CommonSenseKnowledge
 :CommonSenseKnowledge a owl:Class ;
+                      rdfs:label "Common Sense Knowledge" ;
                       rdfs:subClassOf :GenericKnowledge ;
                       rdfs:isDefinedBy "TODO"@en ;
                       owl:versionInfo "4.0.0" .
@@ -332,6 +367,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Compatibility
 :Compatibility a owl:Class ;
+               rdfs:label "Compatibility" ;
                rdfs:subClassOf :RepresentationCriterion ;
                owl:disjointWith :Expressiveness ;
                rdfs:isDefinedBy "Measure of how compatible a given knowledge representation is to data standards, and should be related to the degree of flexibility it has in being coded with various standards." .
@@ -339,6 +375,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Competency
 :Competency a owl:Class ;
+            rdfs:label "Competency" ;
             rdfs:subClassOf :SourceCriterion ;
             rdfs:isDefinedBy "TODO"@en ;
             owl:versionInfo "4.0.0" .
@@ -346,6 +383,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ComputationalCost
 :ComputationalCost a owl:Class ;
+                   rdfs:label "Computational Cost" ;
                    rdfs:subClassOf :PerformanceCriterion ;
                    rdfs:comment "Moved from \"ReasoningCriterion\" in version 4.0.0." ;
                    rdfs:isDefinedBy "Measure of how much of the system’s computational resources are required by a given representational technique to produce its results." ;
@@ -354,6 +392,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Confidentiality
 :Confidentiality a owl:Class ;
+                 rdfs:label "Confidentiality" ;
                  rdfs:subClassOf :InformationHandlingCriterion ;
                  rdfs:isDefinedBy "TODO" ;
                  owl:versionInfo "4.0.0" .
@@ -361,6 +400,7 @@ Technologies for Uncertainty Representation Working Group
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Configurality
 :Configurality a owl:Class ;
+               rdfs:label "Configurality" ;
                rdfs:subClassOf :Expressiveness ;
                rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability of an uncertainty representation to support combining uncertainty about many propositions and/or variables, of different types, with different types of uncertainty.""" .
@@ -368,58 +408,68 @@ Ability of an uncertainty representation to support combining uncertainty about 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Consistency
 :Consistency a owl:Class ;
+             rdfs:label "Consistency" ;
              rdfs:subClassOf :ReasoningCriterion ;
              rdfs:isDefinedBy "Measure of the ability of the reasoning process to produce the same results when provided with the same data under the same conditions." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Credibility
 :Credibility a owl:Class ;
+             rdfs:label "Credibility" ;
              rdfs:subClassOf :InformationCriterion ;
              rdfs:isDefinedBy "Measure of the degree to which an evaluation subject can be believed or accepted as true, real, or honest." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DataInput
 :DataInput a owl:Class ;
+           rdfs:label "Data Input" ;
            rdfs:subClassOf :FusionSystem ;
            owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DataOutput
 :DataOutput a owl:Class ;
+            rdfs:label "Data Output" ;
             rdfs:subClassOf :FusionSystem ;
             owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DataProcessingTechnique
 :DataProcessingTechnique a owl:Class ;
+                         rdfs:label "Data Processing Technique" ;
                          rdfs:subClassOf :FusionSystem ;
                          owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Dependency
 :Dependency a owl:Class ;
+            rdfs:label "Dependency" ;
             rdfs:subClassOf :Expressiveness ;
             rdfs:isDefinedBy "Ability of the uncertainty representation to capture dependency among propositions (e.g., cause and effect, relevance, statistical association)." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DissonantEvidence
 :DissonantEvidence a owl:Class ;
+                   rdfs:label "Dissonant Evidence" ;
                    rdfs:subClassOf :UncertainEvidence .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Epistemic
 :Epistemic a owl:Class ;
+           rdfs:label "Epistemic" ;
            rdfs:subClassOf :UncertaintyNature .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationCriterion
 :EvaluationCriterion a owl:Class ;
+                     rdfs:label "Evaluation Criterion" ;
                      rdfs:subClassOf owl:Thing ;
                      rdfs:isDefinedBy "Encompasses all the different aspects that must be considered when evaluating uncertainty handling in multi-sensor fusion systems" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationMeasure
 :EvaluationMeasure a owl:Class ;
+                   rdfs:label "Evaluation Measure" ;
                    rdfs:subClassOf owl:Thing ;
                    rdfs:comment "Examples covers: STANAG2511Credibility, STANAG2511Reliability, Shanon entropy..." ,
                                 "TODO: what about quantitative versus qualitiative?" ;
@@ -429,6 +479,7 @@ Ability of an uncertainty representation to support combining uncertainty about 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationProcess
 :EvaluationProcess a owl:Class ;
+                   rdfs:label "Evaluation Process" ;
                    rdfs:subClassOf owl:Thing ;
                    rdfs:comment """Entities of the Evaluation class are actual evaluations. 
 According to Patton, Evaluation is a process that critically examines a program. It involves collecting and analyzing information about a program's activities, characteristics, and outcomes. Its purpose is to make judgments about a program, to improve its effectiveness, and/or to inform programming decisions. 
@@ -437,12 +488,14 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationSubject
 :EvaluationSubject a owl:Class ;
+                   rdfs:label "Evaluation Subject" ;
                    rdfs:subClassOf owl:Thing ;
                    rdfs:comment "An Evaluation Subject is an item which can be assessed according to the criteria defined in the URREF ontology."@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Evidence
 :Evidence a owl:Class ;
+          rdfs:label "Evidence" ;
           rdfs:subClassOf owl:Thing ;
           rdfs:comment "An expression in some logical language that evaluates to a truth-value (formula, axiom, assertion). It is then assumed that information will be presented in the form of sentences. So the uncertainty will be associated with sentences."@en ,
                        """Evidence, for the purpose of this ontology is considered to be equivalent to:
@@ -455,6 +508,7 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Explainability
 :Explainability a owl:Class ;
+                rdfs:label "Explainability" ;
                 rdfs:subClassOf :InformationCriterion ;
                 rdfs:isDefinedBy "TODO" ;
                 owl:versionInfo "4.0.0" .
@@ -462,12 +516,14 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Expressiveness
 :Expressiveness a owl:Class ;
+                rdfs:label "Expressiveness" ;
                 rdfs:subClassOf :RepresentationCriterion ;
                 rdfs:isDefinedBy "Measure of the power of a knowledge representation formalism to convey all relevant aspects of a given fusion problem." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionMethod
 :FusionMethod a owl:Class ;
+             rdfs:label "Fusion Method" ;
              rdfs:subClassOf owl:Thing ;
               rdfs:isDefinedBy "TODO" ;
               owl:versionInfo "4.0.0" .
@@ -475,11 +531,13 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionSystem
 :FusionSystem a owl:Class ;
+              rdfs:label "Fusion System" ;
               rdfs:subClassOf owl:Thing .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionSystemComponent
 :FusionSystemComponent a owl:Class ;
+                       rdfs:label "Fusion System Component" ;
                        rdfs:subClassOf owl:Thing ;
                        owl:deprecated "true"^^xsd:boolean ;
                        owl:versionInfo "4.0.0" .
@@ -487,6 +545,7 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionSystemProcess
 :FusionSystemProcess a owl:Class ;
+                     rdfs:label "Fusion System Process" ;
                      rdfs:subClassOf owl:Thing ;
                      owl:deprecated "true"^^xsd:boolean ;
                      owl:versionInfo "4.0.0" .
@@ -494,12 +553,14 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FuzzySets
 :FuzzySets a owl:Class ;
+           rdfs:label "Fuzzy Sets" ;
            rdfs:subClassOf :UncertaintyTheory ;
            rdfs:comment "In contrast to probabilistic formalisms, which allow for representing and processing degrees of uncertainty about ambiguous pieces of information, fuzzy formalisms allow for representing and processing degrees of truth about vague (or imprecise) pieces of information. It is important to point out that vague statements are truth-functional, that is, the degree of truth of a vague complex statement (which is constructed from elementary vague statements via logical operators) can be calculated from the degrees of truth of its constituents, while uncertain complex statements are generally not a function of the degrees of uncertainty of their constituents (Dubois and Prade, 1994)."@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#GenericKnowledge
 :GenericKnowledge a owl:Class ;
+                  rdfs:label "Generic Knowledge" ;
                   rdfs:subClassOf :Information ;
                   rdfs:isDefinedBy "TODO"@en ;
                   rdfs:seeAlso "TODO: ref (ChatGPT paper)" ;
@@ -508,6 +569,7 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HigherOrderUncertainty
 :HigherOrderUncertainty a owl:Class ;
+                        rdfs:label "Higher Order Uncertainty" ;
                         rdfs:subClassOf :Expressiveness ;
                         rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability of the system to represent uncertainty about the uncertainty model, including parameters, structure, and/or type of  model. """ .
@@ -515,20 +577,24 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#IncompleteEvidence
 :IncompleteEvidence a owl:Class ;
+                    rdfs:label "Incomplete Evidence" ;
                     rdfs:subClassOf :UncertainEvidence .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InconclusiveEvidence
 :InconclusiveEvidence a owl:Class ;
+                      rdfs:label "Inconclusive Evidence" ;
                       rdfs:subClassOf :UncertainEvidence .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Information
 :Information a owl:Class ;
+             rdfs:label "Information" ;
              rdfs:subClassOf owl:Thing .
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InformationCriterion
 :InformationCriterion a owl:Class ;
+                      rdfs:label "Information Criterion" ;
                       rdfs:subClassOf :EvaluationCriterion ;
                       rdfs:comment "Renammed from \"DataCriteron\" as of version 4.0.0."@en ;
                       rdfs:isDefinedBy "Evaluation Criteria that concern aspects of information and their relationship to source, the object being reported upon, and the objectives of the fusion process."@en ;
@@ -538,6 +604,7 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InformationHandlingCriterion
 :InformationHandlingCriterion a owl:Class ;
+                              rdfs:label "Information Handling Criterion" ;
                               rdfs:subClassOf :EvaluationCriterion ;
                               rdfs:comment "Renamed from \"DataHandlingCriterion\" in version 4.0.0." ;
                               rdfs:isDefinedBy "Measure of the way data is managed by the fusion system." ;
@@ -546,12 +613,14 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InformationHandlingMethod
 :InformationHandlingMethod a owl:Class ;
+                           rdfs:label "Information Handling Method" ;
                            rdfs:isDefinedBy "TODO" ;
                            owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Integrity
 :Integrity a owl:Class ;
+           rdfs:label "Integrity" ;
            rdfs:subClassOf :InformationHandlingCriterion ;
            rdfs:isDefinedBy "TODO" ;
            owl:versionInfo "4.0.0" .
@@ -559,6 +628,7 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Interpretability
 :Interpretability a owl:Class ;
+                  rdfs:label "Interpretability" ;
                   rdfs:subClassOf :ReasoningCriterion ;
                   rdfs:isDefinedBy "TODO" ;
                   owl:versionInfo "4.0.0" .
@@ -566,6 +636,7 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Interpretation
 :Interpretation a owl:Class ;
+                rdfs:label "Interpretation" ;
                 rdfs:subClassOf owl:Thing ;
                 owl:deprecated "true"^^xsd:boolean ;
                 owl:versionInfo "4.0.0" .
@@ -573,17 +644,20 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Interval
 :Interval a owl:Class ;
+          rdfs:label "Interval" ;
           rdfs:subClassOf :TypeOfScale .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#KnowledgeHandling
 :KnowledgeHandling a owl:Class ;
+                   rdfs:label "Knowledge Handling" ;
                    rdfs:subClassOf :RepresentationCriterion ;
                    rdfs:isDefinedBy "Measure the ability of a given uncertainty representation technique to convey knowledge."@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#LogicalRule
 :LogicalRule a owl:Class ;
+             rdfs:label "Logical Rule" ;
              rdfs:subClassOf :GenericKnowledge ;
              rdfs:isDefinedBy "TODO"@en ;
              owl:versionInfo "4.0.0" .
@@ -591,16 +665,19 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Nominal
 :Nominal a owl:Class ;
+         rdfs:label "Nominal" ;
          rdfs:subClassOf :TypeOfScale .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Objective
 :Objective a owl:Class ;
+           rdfs:label "Objective" ;
            rdfs:subClassOf :UncertaintyDerivation .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Objectivity
 :Objectivity a owl:Class ;
+             rdfs:label "Objectivity" ;
              rdfs:subClassOf :SourceCriterion ;
              rdfs:isDefinedBy "Measure of the extent to which an evaluation subject reports about a matter of fact in an unbiased manner." ;
              owl:incompatibleWith 4 ;
@@ -609,6 +686,7 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Observation
 :Observation a owl:Class ;
+             rdfs:label "Observation" ;
              rdfs:subClassOf :SingularEvidence ;
              rdfs:isDefinedBy "TODO"@en ;
              owl:versionInfo "4.0.0" .
@@ -616,6 +694,7 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ObservationalSensitivity
 :ObservationalSensitivity a owl:Class ;
+                          rdfs:label "Observational Sensitivity" ;
                           rdfs:subClassOf :Credibility ,
                                           :SourceCriterion ;
                           rdfs:isDefinedBy "Quotient of the change in a result of evaluation subject  and the corresponding change in a value of a quality being observed." ;
@@ -626,11 +705,13 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Ordinal
 :Ordinal a owl:Class ;
+         rdfs:label "Ordinal" ;
          rdfs:subClassOf :TypeOfScale .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Outcomes
 :Outcomes a owl:Class ;
+          rdfs:label "Outcomes" ;
           rdfs:subClassOf :Expressiveness ;
           rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability to represent different kinds of outcomes for uncertain variables, e.g., Boolean, qualitative categorical, ordinal, discrete numerical, continuous.""" .
@@ -638,6 +719,7 @@ Ability to represent different kinds of outcomes for uncertain variables, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#PerformanceCriterion
 :PerformanceCriterion a owl:Class ;
+                      rdfs:label "Performance Criterion" ;
                       rdfs:subClassOf :EvaluationCriterion ;
                       rdfs:comment "Moved from \"ReasoningCriterion\" and renamed from \"Performance\" in version 4.0.0." ;
                       rdfs:isDefinedBy "Measure how suitable the representational model is to handle the functional requirements of an information fusion system. Other system architecture factors also affect these metrics." ;
@@ -646,6 +728,7 @@ Ability to represent different kinds of outcomes for uncertain variables, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#PhysicalRule
 :PhysicalRule a owl:Class ;
+              rdfs:label "Physical Rule" ;
               rdfs:subClassOf :GenericKnowledge ;
               rdfs:isDefinedBy "TODO"@en ;
               owl:versionInfo "4.0.0" .
@@ -653,6 +736,7 @@ Ability to represent different kinds of outcomes for uncertain variables, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Precision
 :Precision a owl:Class ;
+           rdfs:label "Precision" ;
            rdfs:subClassOf :Quality ;
            rdfs:isDefinedBy """TODO, decide between :
 - The extent to which a piece of information covers different values.
@@ -662,18 +746,21 @@ Ability to represent different kinds of outcomes for uncertain variables, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Probability
 :Probability a owl:Class ;
+             rdfs:label "Probability" ;
              rdfs:subClassOf :UncertaintyTheory ;
              rdfs:comment "Probability theory provides a mathematically sound representation language and formal calculus for rational degrees of belief, which gives different agents the freedom to have different beliefs about a given hypothesis."@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Quality
 :Quality a owl:Class ;
+         rdfs:label "Quality" ;
          rdfs:subClassOf :InformationCriterion ;
          rdfs:isDefinedBy "Ability to assess the degree of informational quality of the data" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#RandomSets
 :RandomSets a owl:Class ;
+            rdfs:label "Random Sets" ;
             rdfs:subClassOf :UncertaintyTheory ;
             rdfs:comment "A rough set, first described by a Polish computer scientist Zdzisław I. Pawlak, is a formal approximation of a crisp set (i.e., conventional set) in terms of a pair of sets which give the lower and the upper approximation of the original set. In the standard version of rough set theory (Pawlak 1991), the lower- and upper-approximation sets are crisp sets, but in other variations, the approximating sets may be fuzzy set"@en ;
             rdfs:isDefinedBy "http://en.wikipedia.org/wiki/Rough_sets"^^xsd:anyURI .
@@ -681,17 +768,20 @@ Ability to represent different kinds of outcomes for uncertain variables, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Ratio
 :Ratio a owl:Class ;
+       rdfs:label "Ratio" ;
        rdfs:subClassOf :TypeOfScale .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ReasoningCriterion
 :ReasoningCriterion a owl:Class ;
+                    rdfs:label "Reasoning Criterion" ;
                     rdfs:subClassOf :EvaluationCriterion ;
                     rdfs:isDefinedBy "Encompasses criteria directly affecting how an information fusion system transforms its input data into knowledge. It can also be called as process or inference criteria, as it deals with how the uncertainty model performs operations with information." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Relational
 :Relational a owl:Class ;
+            rdfs:label "Relational" ;
             rdfs:subClassOf :Expressiveness ;
             rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability to represent uncertainty about domains with relational structure, e.g.,   attribute value uncertainty; reference uncertainty; type uncertainty; existence uncertainty.""" .
@@ -699,12 +789,14 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#RelevanceToProblem
 :RelevanceToProblem a owl:Class ;
+                    rdfs:label "Relevance To Problem" ;
                     rdfs:subClassOf :InformationCriterion ;
                     rdfs:isDefinedBy "Measure the degree to which an evaluation subject has direct bearing on the objectives of the fusion process. " .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Reliability
 :Reliability a owl:Class ;
+             rdfs:label "Reliability" ;
              rdfs:subClassOf :SourceCriterion ;
              rdfs:isDefinedBy "TODO"@en ;
              owl:versionInfo "4.0.0" .
@@ -712,12 +804,14 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#RepresentationCriterion
 :RepresentationCriterion a owl:Class ;
+                         rdfs:label "Representation Criterion" ;
                          rdfs:subClassOf :EvaluationCriterion ;
                          rdfs:isDefinedBy "Encompasses criteria related to how uncertainty is characterized, captured and stored in a manner that can be processed by the fusion system. " .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Reputation
 :Reputation a owl:Class ;
+            rdfs:label "Reputation" ;
             rdfs:subClassOf :SourceCriterion ;
             rdfs:isDefinedBy "TODO"@en ;
             owl:versionInfo "4.0.0" .
@@ -725,6 +819,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#RoughSets
 :RoughSets a owl:Class ;
+           rdfs:label "Rough Sets" ;
            rdfs:subClassOf :UncertaintyTheory .
 
 
@@ -748,12 +843,14 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Scalability
 :Scalability a owl:Class ;
+             rdfs:label "Scalability" ;
              rdfs:subClassOf :ReasoningCriterion ;
              rdfs:isDefinedBy "Measure of the ability to handle a growing amount of work in a capable manner or its ability to be enlarged to accommodate that growth." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SelfConfidence
 :SelfConfidence a owl:Class ;
+                rdfs:label "Self Confidence" ;
                 rdfs:subClassOf :Credibility ,
                                 :SourceCriterion ;
                 rdfs:isDefinedBy "Measure of the evaluation subject's assessment of its own credibility." ;
@@ -764,6 +861,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SensorMeasurement
 :SensorMeasurement a owl:Class ;
+                   rdfs:label "Sensor Measurement" ;
                    rdfs:subClassOf :SingularEvidence ;
                    rdfs:isDefinedBy "TODO"@en ;
                    owl:versionInfo "4.0.0" .
@@ -771,12 +869,14 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Simplicity
 :Simplicity a owl:Class ;
+            rdfs:label "Simplicity" ;
             rdfs:subClassOf :RepresentationCriterion ;
             rdfs:isDefinedBy "Assesses the information system's ability to execute common operations without requiring deep knowledge about its inner details. " .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SingularEvidence
 :SingularEvidence a owl:Class ;
+                  rdfs:label "Singular Evidence" ;
                   rdfs:subClassOf :Information ;
                   rdfs:isDefinedBy "TODO"@en ;
                   rdfs:seeAlso "TODO: ref (ChatGPT paper)" ;
@@ -785,6 +885,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Soudness
 :Soudness a owl:Class ;
+          rdfs:label "Soudness" ;
           rdfs:subClassOf :ReasoningCriterion ;
           rdfs:comment "Changed name in version 4.0.0: from \"Correctness\" to \"Soundness\"."@en ;
           rdfs:isDefinedBy "The quality of being based on valid reason or good judgement."@en ;
@@ -794,12 +895,14 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Source
 :Source a owl:Class ;
+        rdfs:label "Source" ;
         rdfs:subClassOf owl:Thing ;
         rdfs:comment "A source is the origin of the information."@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SourceCriterion
 :SourceCriterion a owl:Class ;
+                 rdfs:label "Source Criterion" ;
                  rdfs:subClassOf :EvaluationCriterion ;
                  rdfs:isDefinedBy "Any feature of the source which will affect the quality of the information provided by the source."@en ;
                  owl:versionInfo "4.0.0" .
@@ -807,6 +910,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#StatisticalModel
 :StatisticalModel a owl:Class ;
+                  rdfs:label "Statistical Model" ;
                   rdfs:subClassOf :GenericKnowledge ;
                   rdfs:isDefinedBy "TODO"@en ;
                   owl:versionInfo "4.0.0" .
@@ -814,11 +918,13 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Subjective
 :Subjective a owl:Class ;
+            rdfs:label "Subjective" ;
             rdfs:subClassOf :UncertaintyDerivation .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Testimony
 :Testimony a owl:Class ;
+           rdfs:label "Testimony" ;
            rdfs:subClassOf :SingularEvidence ;
            rdfs:isDefinedBy "TODO"@en ;
            owl:versionInfo "4.0.0" .
@@ -826,6 +932,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Throughput
 :Throughput a owl:Class ;
+            rdfs:label "Throughput" ;
             rdfs:subClassOf :PerformanceCriterion ;
             rdfs:isDefinedBy "Measure of the average (and (possibly peak) rate of conversion of inputs to outputs." ;
             owl:versionInfo "4.0.0" .
@@ -833,6 +940,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Timeliness
 :Timeliness a owl:Class ;
+            rdfs:label "Timeliness" ;
             rdfs:subClassOf :PerformanceCriterion ;
             rdfs:isDefinedBy "Measure of the ability to produce results within a required timeframe." ;
             owl:versionInfo "4.0.0" .
@@ -840,12 +948,14 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Traceability
 :Traceability a owl:Class ;
+              rdfs:label "Traceability" ;
               rdfs:subClassOf :InformationHandlingCriterion ;
               rdfs:isDefinedBy "Measure of the ability of a fusion system to provide an accurate and unbroken historical record of its inputs and the chain of operations that led to its conclusions." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Transparency
 :Transparency a owl:Class ;
+              rdfs:label "Transparency" ;
               rdfs:subClassOf :SourceCriterion ;
               rdfs:isDefinedBy "TODO" ;
               owl:versionInfo "4.0.0" .
@@ -853,6 +963,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Trust
 :Trust a owl:Class ;
+       rdfs:label "Trust" ;
        rdfs:subClassOf owl:Thing ;
        rdfs:isDefinedBy "TODO: placeholder to import trust ontologies" ;
        owl:versionInfo "4.0.0" .
@@ -860,11 +971,13 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#TypeOfScale
 :TypeOfScale a owl:Class ;
+             rdfs:label "Type Of Scale" ;
              rdfs:subClassOf owl:Thing .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertainEvidence
 :UncertainEvidence a owl:Class ;
+                   rdfs:label "Uncertain Evidence" ;
                    rdfs:subClassOf :InformationCriterion ;
                    rdfs:comment "Moved as a subclass of InformationCriterion in version 4.0.0." ;
                    rdfs:isDefinedBy "TODO" ;
@@ -873,6 +986,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyDerivation
 :UncertaintyDerivation a owl:Class ;
+                       rdfs:label "Uncertainty Derivation" ;
                        rdfs:subClassOf owl:Thing ;
                        rdfs:comment "Uncertainty derivation refers to the way it can be assessed. That is, how the uncertainty metrics can be derived."@en ;
                        rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
@@ -880,6 +994,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyModel
 :UncertaintyModel a owl:Class ;
+                  rdfs:label "Uncertainty Model" ;
                   rdfs:subClassOf owl:Thing ;
                   rdfs:comment "Renamed from \"UncertaintyFunction\" in version 4.0.0." ;
                   rdfs:isDefinedBy """TODO:
@@ -890,6 +1005,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyNature
 :UncertaintyNature a owl:Class ;
+                   rdfs:label "Uncertainty Nature" ;
                    rdfs:subClassOf owl:Thing ;
                    rdfs:comment "This captures the information about the nature of the uncertainty, i.e., whether the uncertainty is inherent in the phenomenon expressed by the sentence, or it is the result of lack of knowledge of the agent."@en ;
                    rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
@@ -897,6 +1013,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyReasoning
 :UncertaintyReasoning a owl:Class ;
+                      rdfs:label "Uncertainty Reasoning" ;
                       rdfs:subClassOf owl:Thing ;
                       rdfs:isDefinedBy "TODO" ;
                       owl:versionInfo "4.0.0" .
@@ -904,23 +1021,27 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyRepresentation
 :UncertaintyRepresentation a owl:Class ;
+                           rdfs:label "Uncertainty Representation" ;
                            rdfs:subClassOf owl:Thing .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintySupport
 :UncertaintySupport a owl:Class ;
+                    rdfs:label "Uncertainty Support" ;
                     rdfs:subClassOf owl:Thing ;
                     rdfs:isDefinedBy "TODO: what you are certain about." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyTheory
 :UncertaintyTheory a owl:Class ;
+                   rdfs:label "Uncertainty Theory" ;
                    rdfs:subClassOf owl:Thing ;
                    rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyType
 :UncertaintyType a owl:Class ;
+                 rdfs:label "Uncertainty Type" ;
                  rdfs:subClassOf owl:Thing ;
                  rdfs:comment "Uncertainty Type is a concept that focuses on underlying characteristics of the information that make it uncertain. "@en ,
                               """For the purposes of this ontology, Uncertainty type is equivalent to:
@@ -930,12 +1051,14 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UnreliableEvidence
 :UnreliableEvidence a owl:Class ;
+                    rdfs:label "Unreliable Evidence" ;
                     rdfs:subClassOf owl:Thing ;
                     rdfs:subClassOf :UncertainEvidence .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Veracity
 :Veracity a owl:Class ;
+          rdfs:label "Veracity" ;
           rdfs:subClassOf :SourceCriterion ;
           rdfs:isDefinedBy "Measure of the extent to which a source reports what it assesses to be the case." ;
           owl:incompatibleWith 4 ;
@@ -944,6 +1067,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#WeightOfInformation
 :WeightOfInformation a owl:Class ;
+                     rdfs:label "Weight Of Information" ;
                      rdfs:subClassOf :InformationCriterion ;
                      rdfs:comment "Renamed from \"WeightOfEvidence\" in version 4.0.0."@en ;
                      rdfs:isDefinedBy "Measure of the degree of impact of an evaluation subject on the result of fusion. " ;

--- a/URREF.ttl
+++ b/URREF.ttl
@@ -4,21 +4,21 @@
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl> .
 
+# TODO: license
 <http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl> rdf:type owl:Ontology ;
-                                                        owl:versionIRI <http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl> ;
-                                                        owl:priorVersion "v3c"@en ;
-                                                        owl:versionInfo """v2a: ETURWG GM40
+    rdfs:label "URREF" ;
+    owl:versionIRI <http://eturwg.c4i.gmu.edu/files/ontologies/URREF_4.0.1.owl> ;
+    owl:versionInfo "v4.0.1" ;
+    owl:priorVersion "v4.0.0" ;
+    rdfs:comment """v2a: ETURWG GM40
 v2b: ETURWG GM41
 v2c: ETURWG GM49
 v2d: ETURWG GM55
 v3: ETURWG GM83
 v3a: ETURWG GM90
-V3b: ETURWG GM102 F18 F2F
-Current: v3c
-Development: v4.0.0"""@en ,
-                                                                        "v4.0.0"@en .
+v3b: ETURWG GM102 F18 F2F
+v4.0.0: ETURWG""" .
 
 #################################################################
 #    Object Properties

--- a/URREF.ttl
+++ b/URREF.ttl
@@ -4,9 +4,13 @@
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @base <http://eturwg.c4i.gmu.edu/files/ontologies/URREF#> .
 
 <http://eturwg.c4i.gmu.edu/files/ontologies/URREF> a owl:Ontology ;
+                                                    dcterms:modified "2024-04-11" ;
+                                                    owl:priorVersion "v4.0.0" ;
+                                                    owl:versionInfo "v4.0.1" ;
                                                     owl:versionIRI <http://eturwg.c4i.gmu.edu/files/ontologies/URREF/4.0.1/URREF> ;
                                                     rdfs:comment """v2a: ETURWG GM40
 v2b: ETURWG GM41
@@ -17,8 +21,37 @@ v3a: ETURWG GM90
 v3b: ETURWG GM102 F18 F2F
 v4.0.0: ETURWG""" ;
                                                     rdfs:label "URREF" ;
-                                                    owl:priorVersion "v4.0.0" ;
-                                                    owl:versionInfo "v4.0.1" .
+                                                    dcterms:title "Uncertainty Representation and Reasoning Evaluation Framework's Ontology" ;
+                                                    dcterms:description "A taxonomy for modeling uncertain information." ;
+                                                    dcterms:abstract """Current advances in technology, sensor collection, data
+storage, and data distribution have afforded more complex,
+distributed, and operational information fusion systems (IFSs). IFSs
+notionally consist of low-level (data collection, registration, and
+association in time and space) and high-level information fusion
+(user coordination, situational awareness, and mission control),
+which require a common ontology for effective communication and
+data processing. This ontology reference
+model is developed as part of the uncertainty representation and
+reasoning evaluation framework (URREF). The URREF ontology is
+intended to provide guidance for defining the actual concepts and
+criteria that together comprise the comprehensive uncertainty
+evaluation framework being developed by the Evaluation of
+Technologies for Uncertainty Representation Working Group
+(ETURWG) of the International Society of Information Fusion (ISIF).""" ;
+                                                    dcterms:bibliographicCitation """@inproceedings{costa2012towards,
+  title={Towards unbiased evaluation of uncertainty reasoning: The URREF ontology},
+  author={Costa, Paulo C.G. and Laskey, Kathryn B. and Blasch, Erik and Jousselme, Anne-Laure},
+  booktitle={15th International Conference on Information Fusion},
+  pages={2301--2308},
+  year={2012},
+  organization={IEEE}
+}""" ;
+                                                    dcterms:bibliographicCitation "" ;
+                                                    dcterms:creator "Evaluation of Technologies for Uncertainty Representation Working Group" ;
+                                                    dcterms:publisher "International Society of Information Fusion" ;
+                                                    dcterms:language "en" ;
+                                                    dcterms:license "FIXME".
+
 
 #################################################################
 #    Object Properties

--- a/URREF.ttl
+++ b/URREF.ttl
@@ -105,14 +105,8 @@ v4.0.0: ETURWG""" ;
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesTo
 :appliesTo rdf:type owl:ObjectProperty ;
-           rdfs:domain [ rdf:type owl:Restriction ;
-                         owl:onProperty :appliesTo ;
-                         owl:someValuesFrom :UncertaintyRepresentation
-                       ] ;
-           rdfs:range [ rdf:type owl:Restriction ;
-                        owl:onProperty :appliesTo ;
-                        owl:someValuesFrom :RepresentationCriterion
-                      ] ;
+           rdfs:domain :UncertaintyRepresentation ;
+           rdfs:range :RepresentationCriterion ;
            rdfs:isDefinedBy "TODO" ;
            owl:versionInfo "4.0.0" .
 
@@ -120,14 +114,8 @@ v4.0.0: ETURWG""" ;
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesToHandling
 :appliesToHandling rdf:type owl:ObjectProperty ;
                    rdfs:subPropertyOf :appliesTo ;
-                   rdfs:domain [ rdf:type owl:Restriction ;
-                                 owl:onProperty :appliesToHandling ;
-                                 owl:someValuesFrom :InformationHandlingMethod
-                               ] ;
-                   rdfs:range [ rdf:type owl:Restriction ;
-                                owl:onProperty :appliesToHandling ;
-                                owl:someValuesFrom :InformationHandlingCriterion
-                              ] ;
+                   rdfs:domain :InformationHandlingMethod ;
+                   rdfs:range :InformationHandlingCriterion ;
                    rdfs:isDefinedBy "TODO" ;
                    owl:versionInfo "4.0.0" .
 
@@ -135,14 +123,8 @@ v4.0.0: ETURWG""" ;
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesToReasoning
 :appliesToReasoning rdf:type owl:ObjectProperty ;
                     rdfs:subPropertyOf :appliesTo ;
-                    rdfs:domain [ rdf:type owl:Restriction ;
-                                  owl:onProperty :appliesToReasoning ;
-                                  owl:someValuesFrom :UncertaintyReasoning
-                                ] ;
-                    rdfs:range [ rdf:type owl:Restriction ;
-                                 owl:onProperty :appliesToReasoning ;
-                                 owl:someValuesFrom :ReasoningCriterion
-                               ] ;
+                    rdfs:domain :UncertaintyReasoning ;
+                    rdfs:range :ReasoningCriterion ;
                     rdfs:isDefinedBy "TODO" ;
                     owl:versionInfo "4.0.0" .
 
@@ -150,14 +132,8 @@ v4.0.0: ETURWG""" ;
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesToRepresentation
 :appliesToRepresentation rdf:type owl:ObjectProperty ;
                          rdfs:subPropertyOf :appliesTo ;
-                         rdfs:domain [ rdf:type owl:Restriction ;
-                                       owl:onProperty :appliesTo ;
-                                       owl:someValuesFrom :UncertaintyRepresentation
-                                     ] ;
-                         rdfs:range [ rdf:type owl:Restriction ;
-                                      owl:onProperty :appliesTo ;
-                                      owl:someValuesFrom :RepresentationCriterion
-                                    ] ;
+                         rdfs:domain :UncertaintyRepresentation ;
+                         rdfs:range :RepresentationCriterion ;
                          rdfs:isDefinedBy "TODO" ;
                          owl:versionInfo "4.0.0" .
 
@@ -171,36 +147,18 @@ v4.0.0: ETURWG""" ;
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#basedOn
 :basedOn rdf:type owl:ObjectProperty ;
-         rdfs:domain [ rdf:type owl:Restriction ;
-                       owl:onProperty :basedOn ;
-                       owl:someValuesFrom :InformationHandlingMethod
-                     ] ,
-                     [ rdf:type owl:Restriction ;
-                       owl:onProperty :basedOn ;
-                       owl:someValuesFrom :UncertaintyReasoning
-                     ] ,
-                     [ rdf:type owl:Restriction ;
-                       owl:onProperty :basedOn ;
-                       owl:someValuesFrom :UncertaintyRepresentation
-                     ] ;
-         rdfs:range [ rdf:type owl:Restriction ;
-                      owl:onProperty :basedOn ;
-                      owl:someValuesFrom :FusionMethod
-                    ] ;
+         rdfs:domain :InformationHandlingMethod,
+                     :UncertaintyReasoning,
+                     :UncertaintyRepresentation ;
+         rdfs:range :FusionMethod ;
          rdfs:isDefinedBy "TODO" ;
          owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#employs
 :employs rdf:type owl:ObjectProperty ;
-         rdfs:domain [ rdf:type owl:Restriction ;
-                       owl:onProperty :employs ;
-                       owl:someValuesFrom :EvaluationMeasure
-                     ] ;
-         rdfs:range [ rdf:type owl:Restriction ;
-                      owl:onProperty :employs ;
-                      owl:someValuesFrom :EvaluationProcess
-                    ] ;
+         rdfs:domain :EvaluationMeasure ;
+         rdfs:range :EvaluationProcess ;
          rdfs:isDefinedBy "TODO" ;
          owl:versionInfo "4.0.0" .
 
@@ -213,18 +171,9 @@ v4.0.0: ETURWG""" ;
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#impacts
 :impacts rdf:type owl:ObjectProperty ;
-         rdfs:domain [ rdf:type owl:Restriction ;
-                       owl:onProperty :impacts ;
-                       owl:someValuesFrom :InformationCriterion
-                     ] ,
-                     [ rdf:type owl:Restriction ;
-                       owl:onProperty :impacts ;
-                       owl:someValuesFrom :SourceCriterion
-                     ] ;
-         rdfs:range [ rdf:type owl:Restriction ;
-                      owl:onProperty :impacts ;
-                      owl:someValuesFrom :WeightOfInformation
-                    ] ;
+         rdfs:domain :InformationCriterion,
+                     :SourceCriterion ;
+         rdfs:range :WeightOfInformation ;
          rdfs:comment "TODO: decide whether associations are pascalCase or CamelCase."@en ;
          owl:versionInfo "4.0.0" .
 
@@ -238,14 +187,8 @@ v4.0.0: ETURWG""" ;
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#measures
 :measures rdf:type owl:ObjectProperty ;
           rdfs:subPropertyOf owl:topObjectProperty ;
-          rdfs:domain [ rdf:type owl:Restriction ;
-                        owl:onProperty :measures ;
-                        owl:someValuesFrom :EvaluationMeasure
-                      ] ;
-          rdfs:range [ rdf:type owl:Restriction ;
-                       owl:onProperty :measures ;
-                       owl:someValuesFrom :EvaluationCriterion
-                     ] ;
+          rdfs:domain :EvaluationMeasure ;
+          rdfs:range :EvaluationCriterion ;
           rdfs:isDefinedBy "TODO" ;
           owl:versionInfo "4.0.0" .
 

--- a/URREF.ttl
+++ b/URREF.ttl
@@ -1,4 +1,4 @@
-@prefix : <http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl> .
+@prefix : <http://eturwg.c4i.gmu.edu/files/ontologies/URREF#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
@@ -6,7 +6,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 # TODO: license
-<http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl> rdf:type owl:Ontology ;
+<http://eturwg.c4i.gmu.edu/files/ontologies/URREF> rdf:type owl:Ontology ;
     rdfs:label "URREF" ;
     owl:versionIRI <http://eturwg.c4i.gmu.edu/files/ontologies/URREF_4.0.1.owl> ;
     owl:versionInfo "v4.0.1" ;
@@ -24,7 +24,7 @@ v4.0.0: ETURWG""" .
 #    Object Properties
 #################################################################
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#DerivationOfUncertainty
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DerivationOfUncertainty
 :DerivationOfUncertainty rdf:type owl:ObjectProperty ;
                          rdfs:subPropertyOf owl:topObjectProperty ;
                          rdf:type owl:FunctionalProperty ;
@@ -32,78 +32,78 @@ v4.0.0: ETURWG""" .
                          rdfs:range <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyDerivation> .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#GivesDataInputTo
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#GivesDataInputTo
 :GivesDataInputTo rdf:type owl:ObjectProperty ;
-                  rdfs:domain <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Source> .
+                  rdfs:domain <http://eturwg.c4i.gmu.edu/ontologies/URREF#Source> .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#HasEvaluationSubject
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasEvaluationSubject
 :HasEvaluationSubject rdf:type owl:ObjectProperty ;
                       owl:inverseOf :IsSubjectOfEvaluationIn ;
                       rdfs:domain :EvaluationProcess ;
                       rdfs:range :FusionSystem ,
                                  :Information ,
-                                 <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Source> ,
+                                 <http://eturwg.c4i.gmu.edu/ontologies/URREF#Source> ,
                                  <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyTheory> .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#HasImperfection
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasImperfection
 :HasImperfection rdf:type owl:ObjectProperty ;
                  rdfs:domain <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
                  rdfs:range <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyType> .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#HasSource
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasSource
 :HasSource rdf:type owl:ObjectProperty ;
            rdfs:domain :DataInput ,
                        <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
-           rdfs:range <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Source> .
+           rdfs:range <http://eturwg.c4i.gmu.edu/ontologies/URREF#Source> .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#HasUncertaintySupport
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasUncertaintySupport
 :HasUncertaintySupport rdf:type owl:ObjectProperty ,
                                 owl:FunctionalProperty ;
                        rdfs:domain <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
                        rdfs:range :UncertaintySupport .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#IsSubjectOfEvaluationIn
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#IsSubjectOfEvaluationIn
 :IsSubjectOfEvaluationIn rdf:type owl:ObjectProperty ;
                          rdfs:subPropertyOf owl:topObjectProperty ;
                          rdfs:domain :FusionSystem ,
                                      :Information ,
-                                     <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Source> ,
+                                     <http://eturwg.c4i.gmu.edu/ontologies/URREF#Source> ,
                                      <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyTheory> ;
                          rdfs:range :EvaluationProcess .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#NatureOfUncertainty
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#NatureOfUncertainty
 :NatureOfUncertainty rdf:type owl:ObjectProperty ,
                               owl:FunctionalProperty ;
                      rdfs:domain <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
                      rdfs:range <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyNature> .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#OuputAssessedBy
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#OuputAssessedBy
 :OuputAssessedBy rdf:type owl:ObjectProperty ;
                  owl:inverseOf :QualityAssesses ;
                  rdfs:domain :DataOutput ;
-                 rdfs:range <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Quality> .
+                 rdfs:range <http://eturwg.c4i.gmu.edu/ontologies/URREF#Quality> .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#QualityAssesses
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#QualityAssesses
 :QualityAssesses rdf:type owl:ObjectProperty ;
-                 rdfs:domain <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Quality> ;
+                 rdfs:domain <http://eturwg.c4i.gmu.edu/ontologies/URREF#Quality> ;
                  rdfs:range :DataOutput .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#ReadSource
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ReadSource
 :ReadSource rdf:type owl:ObjectProperty ;
             rdfs:domain :DataProcessingTechnique ;
-            rdfs:range <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Source> .
+            rdfs:range <http://eturwg.c4i.gmu.edu/ontologies/URREF#Source> .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#appliesTo
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesTo
 :appliesTo rdf:type owl:ObjectProperty ;
            rdfs:domain [ rdf:type owl:Restriction ;
                          owl:onProperty :appliesTo ;
@@ -111,13 +111,13 @@ v4.0.0: ETURWG""" .
                        ] ;
            rdfs:range [ rdf:type owl:Restriction ;
                         owl:onProperty :appliesTo ;
-                        owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#RepresentationCriterion>
+                        owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion>
                       ] ;
            rdfs:isDefinedBy "TODO" ;
            owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#appliesToHandling
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesToHandling
 :appliesToHandling rdf:type owl:ObjectProperty ;
                    rdfs:subPropertyOf :appliesTo ;
                    rdfs:domain [ rdf:type owl:Restriction ;
@@ -132,7 +132,7 @@ v4.0.0: ETURWG""" .
                    owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#appliesToReasoning
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesToReasoning
 :appliesToReasoning rdf:type owl:ObjectProperty ;
                     rdfs:subPropertyOf :appliesTo ;
                     rdfs:domain [ rdf:type owl:Restriction ;
@@ -141,13 +141,13 @@ v4.0.0: ETURWG""" .
                                 ] ;
                     rdfs:range [ rdf:type owl:Restriction ;
                                  owl:onProperty :appliesToReasoning ;
-                                 owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#ReasoningCriterion>
+                                 owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion>
                                ] ;
                     rdfs:isDefinedBy "TODO" ;
                     owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#appliesToRepresentation
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesToRepresentation
 :appliesToRepresentation rdf:type owl:ObjectProperty ;
                          rdfs:subPropertyOf :appliesTo ;
                          rdfs:domain [ rdf:type owl:Restriction ;
@@ -156,20 +156,20 @@ v4.0.0: ETURWG""" .
                                      ] ;
                          rdfs:range [ rdf:type owl:Restriction ;
                                       owl:onProperty :appliesTo ;
-                                      owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#RepresentationCriterion>
+                                      owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion>
                                     ] ;
                          rdfs:isDefinedBy "TODO" ;
                          owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#assesses
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#assesses
 :assesses rdf:type owl:ObjectProperty ;
           owl:inverseOf :isAssessedBy ;
-          rdfs:domain <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Credibility> ;
+          rdfs:domain <http://eturwg.c4i.gmu.edu/ontologies/URREF#Credibility> ;
           rdfs:range :DataInput .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#basedOn
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#basedOn
 :basedOn rdf:type owl:ObjectProperty ;
          rdfs:domain [ rdf:type owl:Restriction ;
                        owl:onProperty :basedOn ;
@@ -191,7 +191,7 @@ v4.0.0: ETURWG""" .
          owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#employs
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#employs
 :employs rdf:type owl:ObjectProperty ;
          rdfs:domain [ rdf:type owl:Restriction ;
                        owl:onProperty :employs ;
@@ -205,13 +205,13 @@ v4.0.0: ETURWG""" .
          owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#hasInformation
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#hasInformation
 :hasInformation rdf:type owl:ObjectProperty ;
                 rdfs:domain :DataInput ,
-                            <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Source> .
+                            <http://eturwg.c4i.gmu.edu/ontologies/URREF#Source> .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#impacts
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#impacts
 :impacts rdf:type owl:ObjectProperty ;
          rdfs:domain [ rdf:type owl:Restriction ;
                        owl:onProperty :impacts ;
@@ -219,23 +219,23 @@ v4.0.0: ETURWG""" .
                      ] ,
                      [ rdf:type owl:Restriction ;
                        owl:onProperty :impacts ;
-                       owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#InformationCriterion>
+                       owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion>
                      ] ;
          rdfs:range [ rdf:type owl:Restriction ;
                       owl:onProperty :impacts ;
-                      owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#WeightOfInformation>
+                      owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF#WeightOfInformation>
                     ] ;
          rdfs:comment "TODO: decide whether associations are pascalCase or CamelCase."@en ;
          owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#isAssessedBy
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#isAssessedBy
 :isAssessedBy rdf:type owl:ObjectProperty ;
               rdfs:domain :DataInput ;
-              rdfs:range <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Credibility> .
+              rdfs:range <http://eturwg.c4i.gmu.edu/ontologies/URREF#Credibility> .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#measures
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#measures
 :measures rdf:type owl:ObjectProperty ;
           rdfs:subPropertyOf owl:topObjectProperty ;
           rdfs:domain [ rdf:type owl:Restriction ;
@@ -244,7 +244,7 @@ v4.0.0: ETURWG""" .
                       ] ;
           rdfs:range [ rdf:type owl:Restriction ;
                        owl:onProperty :measures ;
-                       owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#EvaluationCriterion>
+                       owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion>
                      ] ;
           rdfs:isDefinedBy "TODO" ;
           owl:versionInfo "4.0.0" .
@@ -254,31 +254,31 @@ v4.0.0: ETURWG""" .
 #    Data properties
 #################################################################
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#HasPieceOfInformation
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasPieceOfInformation
 :HasPieceOfInformation rdf:type owl:DatatypeProperty ;
                        rdfs:domain <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
                        rdfs:range xsd:string .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#HasUncertanitySupport
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasUncertanitySupport
 :HasUncertanitySupport rdf:type owl:DatatypeProperty ;
                        rdfs:domain <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
                        rdfs:range xsd:string .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#TypeOfInformation
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#TypeOfInformation
 :TypeOfInformation rdf:type owl:DatatypeProperty ;
                    rdfs:subPropertyOf owl:topDataProperty ;
                    rdfs:domain <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
                    rdfs:range xsd:string .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#hasCode
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#hasCode
 :hasCode rdf:type owl:DatatypeProperty ,
                   owl:FunctionalProperty .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#usesource
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#usesource
 :usesource rdf:type owl:DatatypeProperty .
 
 
@@ -286,76 +286,76 @@ v4.0.0: ETURWG""" .
 #    Classes
 #################################################################
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Aleatory
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Aleatory
 :Aleatory rdf:type owl:Class ;
           rdfs:subClassOf <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyNature> .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Availability
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Availability
 :Availability rdf:type owl:Class ;
               rdfs:subClassOf :InformationHandlingCriterion ;
               rdfs:isDefinedBy "TODO" ;
               owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#CommonSenseKnowledge
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#CommonSenseKnowledge
 :CommonSenseKnowledge rdf:type owl:Class ;
                       rdfs:subClassOf :GenericKnowledge ;
                       rdfs:isDefinedBy "TODO"@en ;
                       owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Competency
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Competency
 :Competency rdf:type owl:Class ;
             rdfs:subClassOf :SourceCriterion ;
             rdfs:isDefinedBy "TODO"@en ;
             owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Confidentiality
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Confidentiality
 :Confidentiality rdf:type owl:Class ;
                  rdfs:subClassOf :InformationHandlingCriterion ;
                  rdfs:isDefinedBy "TODO" ;
                  owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Configurality
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Configurality
 :Configurality rdf:type owl:Class ;
-               rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Expressiveness> ;
+               rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> ;
                rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability of an uncertainty representation to support combining uncertainty about many propositions and/or variables, of different types, with different types of uncertainty.""" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#DataInput
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DataInput
 :DataInput rdf:type owl:Class ;
            rdfs:subClassOf :FusionSystem ;
            owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#DataOutput
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DataOutput
 :DataOutput rdf:type owl:Class ;
             rdfs:subClassOf :FusionSystem ;
             owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#DataProcessingTechnique
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DataProcessingTechnique
 :DataProcessingTechnique rdf:type owl:Class ;
                          rdfs:subClassOf :FusionSystem ;
                          owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Dependency
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Dependency
 :Dependency rdf:type owl:Class ;
-            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Expressiveness> ;
+            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> ;
             rdfs:isDefinedBy "Ability of the uncertainty representation to capture dependency among propositions (e.g., cause and effect, relevance, statistical association)." .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Epistemic
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Epistemic
 :Epistemic rdf:type owl:Class ;
            rdfs:subClassOf <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyNature> .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#EvaluationMeasure
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationMeasure
 :EvaluationMeasure rdf:type owl:Class ;
                    rdfs:comment "Examples covers: STANAG2511Credibility, STANAG2511Reliability, Shanon entropy..." ,
                                 "TODO: what about quantitative versus qualitiative?" ;
@@ -363,48 +363,48 @@ Ability of an uncertainty representation to support combining uncertainty about 
                    owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#EvaluationProcess
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationProcess
 :EvaluationProcess rdf:type owl:Class ;
                    rdfs:comment """Entities of the Evaluation class are actual evaluations. 
 According to Patton, Evaluation is a process that critically examines a program. It involves collecting and analyzing information about a program's activities, characteristics, and outcomes. Its purpose is to make judgments about a program, to improve its effectiveness, and/or to inform programming decisions. 
 Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA: Sage Publishers.)."""@en .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#EvaluationSubject
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationSubject
 :EvaluationSubject rdf:type owl:Class ;
                    rdfs:comment "An Evaluation Subject is an item which can be assessed according to the criteria defined in the URREF ontology."@en .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Explainability
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Explainability
 :Explainability rdf:type owl:Class ;
-                rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#InformationCriterion> ;
+                rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion> ;
                 rdfs:isDefinedBy "TODO" ;
                 owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#FusionMethod
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionMethod
 :FusionMethod rdf:type owl:Class ;
               rdfs:isDefinedBy "TODO" ;
               owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#FusionSystem
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionSystem
 :FusionSystem rdf:type owl:Class .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#FusionSystemComponent
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionSystemComponent
 :FusionSystemComponent rdf:type owl:Class ;
                        owl:deprecated "true"^^xsd:boolean ;
                        owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#FusionSystemProcess
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionSystemProcess
 :FusionSystemProcess rdf:type owl:Class ;
                      owl:deprecated "true"^^xsd:boolean ;
                      owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#GenericKnowledge
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#GenericKnowledge
 :GenericKnowledge rdf:type owl:Class ;
                   rdfs:subClassOf :Information ;
                   rdfs:isDefinedBy "TODO"@en ;
@@ -412,159 +412,159 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
                   owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#HigherOrderUncertainty
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HigherOrderUncertainty
 :HigherOrderUncertainty rdf:type owl:Class ;
-                        rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Expressiveness> ;
+                        rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> ;
                         rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability of the system to represent uncertainty about the uncertainty model, including parameters, structure, and/or type of  model. """ .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Information
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Information
 :Information rdf:type owl:Class .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#InformationHandlingCriterion
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InformationHandlingCriterion
 :InformationHandlingCriterion rdf:type owl:Class ;
-                              rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#EvaluationCriterion> ;
+                              rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion> ;
                               rdfs:comment "Renamed from \"DataHandlingCriterion\" in version 4.0.0." ;
                               rdfs:isDefinedBy "Measure of the way data is managed by the fusion system." ;
                               owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#InformationHandlingMethod
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InformationHandlingMethod
 :InformationHandlingMethod rdf:type owl:Class ;
                            rdfs:isDefinedBy "TODO" ;
                            owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Integrity
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Integrity
 :Integrity rdf:type owl:Class ;
            rdfs:subClassOf :InformationHandlingCriterion ;
            rdfs:isDefinedBy "TODO" ;
            owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Interpretability
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Interpretability
 :Interpretability rdf:type owl:Class ;
-                  rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#ReasoningCriterion> ;
+                  rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion> ;
                   rdfs:isDefinedBy "TODO" ;
                   owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Interval
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Interval
 :Interval rdf:type owl:Class ;
           rdfs:subClassOf :TypeOfScale .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#LogicalRule
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#LogicalRule
 :LogicalRule rdf:type owl:Class ;
              rdfs:subClassOf :GenericKnowledge ;
              rdfs:isDefinedBy "TODO"@en ;
              owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Nominal
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Nominal
 :Nominal rdf:type owl:Class ;
          rdfs:subClassOf :TypeOfScale .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Objective
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Objective
 :Objective rdf:type owl:Class ;
            rdfs:subClassOf <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyDerivation> .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Observation
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Observation
 :Observation rdf:type owl:Class ;
              rdfs:subClassOf :SingularEvidence ;
              rdfs:isDefinedBy "TODO"@en ;
              owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#ObservationalSensitivity
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ObservationalSensitivity
 :ObservationalSensitivity rdf:type owl:Class ;
-                          rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Credibility> ;
+                          rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Credibility> ;
                           owl:deprecated "true"^^xsd:boolean ;
                           owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Ordinal
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Ordinal
 :Ordinal rdf:type owl:Class ;
          rdfs:subClassOf :TypeOfScale .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Outcomes
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Outcomes
 :Outcomes rdf:type owl:Class ;
-          rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Expressiveness> ;
+          rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> ;
           rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability to represent different kinds of outcomes for uncertain variables, e.g., Boolean, qualitative categorical, ordinal, discrete numerical, continuous.""" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#PhysicalRule
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#PhysicalRule
 :PhysicalRule rdf:type owl:Class ;
               rdfs:subClassOf :GenericKnowledge ;
               rdfs:isDefinedBy "TODO"@en ;
               owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Ratio
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Ratio
 :Ratio rdf:type owl:Class ;
        rdfs:subClassOf :TypeOfScale .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Relational
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Relational
 :Relational rdf:type owl:Class ;
-            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Expressiveness> ;
+            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> ;
             rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability to represent uncertainty about domains with relational structure, e.g.,   attribute value uncertainty; reference uncertainty; type uncertainty; existence uncertainty.""" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Reliability
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Reliability
 :Reliability rdf:type owl:Class ;
              rdfs:subClassOf :SourceCriterion ;
              rdfs:isDefinedBy "TODO"@en ;
              owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Reputation
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Reputation
 :Reputation rdf:type owl:Class ;
             rdfs:subClassOf :SourceCriterion ;
             rdfs:isDefinedBy "TODO"@en ;
             owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#STANAG2511
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#STANAG2511
 :STANAG2511 rdf:type owl:Class ;
             rdfs:subClassOf :EvaluationMeasure ;
             owl:deprecated "true"^^xsd:boolean .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#STANAG2511Credibility
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#STANAG2511Credibility
 :STANAG2511Credibility rdf:type owl:Class ;
                        rdfs:subClassOf :STANAG2511 ;
                        owl:deprecated "true"^^xsd:boolean .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#STANAG2511Reliability
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#STANAG2511Reliability
 :STANAG2511Reliability rdf:type owl:Class ;
                        rdfs:subClassOf :STANAG2511 ;
                        owl:deprecated "true"^^xsd:boolean .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#SelfConfidence
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SelfConfidence
 :SelfConfidence rdf:type owl:Class ;
-                rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Credibility> ;
+                rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Credibility> ;
                 owl:deprecated "true"^^xsd:boolean ;
                 owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#SensorMeasurement
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SensorMeasurement
 :SensorMeasurement rdf:type owl:Class ;
                    rdfs:subClassOf :SingularEvidence ;
                    rdfs:isDefinedBy "TODO"@en ;
                    owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#SingularEvidence
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SingularEvidence
 :SingularEvidence rdf:type owl:Class ;
                   rdfs:subClassOf :Information ;
                   rdfs:isDefinedBy "TODO"@en ;
@@ -572,50 +572,50 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
                   owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#SourceCriterion
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SourceCriterion
 :SourceCriterion rdf:type owl:Class ;
-                 rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#EvaluationCriterion> ;
+                 rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion> ;
                  rdfs:isDefinedBy "Any feature of the source which will affect the quality of the information provided by the source."@en ;
                  owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#StatisticalModel
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#StatisticalModel
 :StatisticalModel rdf:type owl:Class ;
                   rdfs:subClassOf :GenericKnowledge ;
                   rdfs:isDefinedBy "TODO"@en ;
                   owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Subjective
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Subjective
 :Subjective rdf:type owl:Class ;
             rdfs:subClassOf <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyDerivation> .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Testimony
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Testimony
 :Testimony rdf:type owl:Class ;
            rdfs:subClassOf :SingularEvidence ;
            rdfs:isDefinedBy "TODO"@en ;
            owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Transparency
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Transparency
 :Transparency rdf:type owl:Class ;
               rdfs:subClassOf :SourceCriterion ;
               rdfs:isDefinedBy "TODO" ;
               owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#Trust
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Trust
 :Trust rdf:type owl:Class ;
        rdfs:isDefinedBy "TODO: placeholder to import trust ontologies" ;
        owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#TypeOfScale
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#TypeOfScale
 :TypeOfScale rdf:type owl:Class .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#UncertaintyModel
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyModel
 :UncertaintyModel rdf:type owl:Class ;
                   rdfs:comment "Renamed from \"UncertaintyFunction\" in version 4.0.0." ;
                   rdfs:isDefinedBy """TODO:
@@ -624,253 +624,253 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
                   owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#UncertaintyReasoning
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyReasoning
 :UncertaintyReasoning rdf:type owl:Class ;
                       rdfs:isDefinedBy "TODO" ;
                       owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#UncertaintyRepresentation
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyRepresentation
 :UncertaintyRepresentation rdf:type owl:Class .
 
 
-###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF.owl#UncertaintySupport
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintySupport
 :UncertaintySupport rdf:type owl:Class ;
                     rdfs:isDefinedBy "TODO: what you are certain about." .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Accuracy
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Accuracy> rdf:type owl:Class ;
-                                                          rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Quality> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Accuracy
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Accuracy> rdf:type owl:Class ;
+                                                          rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Quality> ;
                                                           rdfs:isDefinedBy "Closeness of agreement between an evaluation subject value and the true value of the quantity or quality being evaluated." .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Adaptability
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Adaptability> rdf:type owl:Class ;
-                                                              rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#RepresentationCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Adaptability
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Adaptability> rdf:type owl:Class ;
+                                                              rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion> ;
                                                               rdfs:isDefinedBy "Ability of the representational model to allow for different configurations of the model. " .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#AmbiguousEvidence
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#AmbiguousEvidence> rdf:type owl:Class ;
-                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#UncertainEvidence> .
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#AmbiguousEvidence
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#AmbiguousEvidence> rdf:type owl:Class ;
+                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#UncertainEvidence> .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Assessment
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Assessment> rdf:type owl:Class ;
-                                                            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Expressiveness> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Assessment
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Assessment> rdf:type owl:Class ;
+                                                            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> ;
                                                             rdfs:isDefinedBy "Measure of the ability of the system to handle the types of uncertainty assessments (e.g., verbal, quantitative, combined) needed for a given problem, and to distinguish them from one another. " .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Compatibility
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Compatibility> rdf:type owl:Class ;
-                                                               rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#RepresentationCriterion> ;
-                                                               owl:disjointWith <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Expressiveness> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Compatibility
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Compatibility> rdf:type owl:Class ;
+                                                               rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion> ;
+                                                               owl:disjointWith <http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> ;
                                                                rdfs:isDefinedBy "Measure of how compatible a given knowledge representation is to data standards, and should be related to the degree of flexibility it has in being coded with various standards." .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#ComputationalCost
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#ComputationalCost> rdf:type owl:Class ;
-                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#PerformanceCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#ComputationalCost
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#ComputationalCost> rdf:type owl:Class ;
+                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#PerformanceCriterion> ;
                                                                    rdfs:comment "Moved from \"ReasoningCriterion\" in version 4.0.0." ;
                                                                    rdfs:isDefinedBy "Measure of how much of the system’s computational resources are required by a given representational technique to produce its results." ;
                                                                    owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Consistency
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Consistency> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#ReasoningCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Consistency
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Consistency> rdf:type owl:Class ;
+                                                             rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion> ;
                                                              rdfs:isDefinedBy "Measure of the ability of the reasoning process to produce the same results when provided with the same data under the same conditions." .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Credibility
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Credibility> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#InformationCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Credibility
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Credibility> rdf:type owl:Class ;
+                                                             rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion> ;
                                                              rdfs:isDefinedBy "Measure of the degree to which an evaluation subject can be believed or accepted as true, real, or honest." .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#DissonantEvidence
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#DissonantEvidence> rdf:type owl:Class ;
-                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#UncertainEvidence> .
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#DissonantEvidence
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#DissonantEvidence> rdf:type owl:Class ;
+                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#UncertainEvidence> .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#EvaluationCriterion
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#EvaluationCriterion> rdf:type owl:Class ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion> rdf:type owl:Class ;
                                                                      rdfs:isDefinedBy "Encompasses all the different aspects that must be considered when evaluating uncertainty handling in multi-sensor fusion systems" .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Expressiveness
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Expressiveness> rdf:type owl:Class ;
-                                                                rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#RepresentationCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> rdf:type owl:Class ;
+                                                                rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion> ;
                                                                 rdfs:isDefinedBy "Measure of the power of a knowledge representation formalism to convey all relevant aspects of a given fusion problem." .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#IncompleteEvidence
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#IncompleteEvidence> rdf:type owl:Class ;
-                                                                    rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#UncertainEvidence> .
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#IncompleteEvidence
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#IncompleteEvidence> rdf:type owl:Class ;
+                                                                    rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#UncertainEvidence> .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#InconclusiveEvidence
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#InconclusiveEvidence> rdf:type owl:Class ;
-                                                                      rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#UncertainEvidence> .
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#InconclusiveEvidence
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#InconclusiveEvidence> rdf:type owl:Class ;
+                                                                      rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#UncertainEvidence> .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#InformationCriterion
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#InformationCriterion> rdf:type owl:Class ;
-                                                                      rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#EvaluationCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion> rdf:type owl:Class ;
+                                                                      rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion> ;
                                                                       rdfs:comment "Renammed from \"DataCriteron\" as of version 4.0.0."@en ;
                                                                       rdfs:isDefinedBy "Evaluation Criteria that concern aspects of information and their relationship to source, the object being reported upon, and the objectives of the fusion process."@en ;
                                                                       owl:incompatibleWith 4 ;
                                                                       owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Interpretation
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Interpretation> rdf:type owl:Class ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Interpretation
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Interpretation> rdf:type owl:Class ;
                                                                 owl:deprecated "true"^^xsd:boolean ;
                                                                 owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#KnowledgeHandling
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#KnowledgeHandling> rdf:type owl:Class ;
-                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#RepresentationCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#KnowledgeHandling
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#KnowledgeHandling> rdf:type owl:Class ;
+                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion> ;
                                                                    rdfs:isDefinedBy "Measure the ability of a given uncertainty representation technique to convey knowledge."@en .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Objectivity
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Objectivity> rdf:type owl:Class ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Objectivity
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Objectivity> rdf:type owl:Class ;
                                                              rdfs:subClassOf :SourceCriterion ;
                                                              rdfs:isDefinedBy "Measure of the extent to which an evaluation subject reports about a matter of fact in an unbiased manner." ;
                                                              owl:incompatibleWith 4 ;
                                                              owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#ObservationalSensitivity
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#ObservationalSensitivity> rdf:type owl:Class ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#ObservationalSensitivity
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#ObservationalSensitivity> rdf:type owl:Class ;
                                                                           rdfs:subClassOf :SourceCriterion ;
                                                                           rdfs:isDefinedBy "Quotient of the change in a result of evaluation subject  and the corresponding change in a value of a quality being observed." ;
                                                                           owl:incompatibleWith 4 ;
                                                                           owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#PerformanceCriterion
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#PerformanceCriterion> rdf:type owl:Class ;
-                                                                      rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#EvaluationCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#PerformanceCriterion
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#PerformanceCriterion> rdf:type owl:Class ;
+                                                                      rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion> ;
                                                                       rdfs:comment "Moved from \"ReasoningCriterion\" and renamed from \"Performance\" in version 4.0.0." ;
                                                                       rdfs:isDefinedBy "Measure how suitable the representational model is to handle the functional requirements of an information fusion system. Other system architecture factors also affect these metrics." ;
                                                                       owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Precision
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Precision> rdf:type owl:Class ;
-                                                           rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Quality> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Precision
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Precision> rdf:type owl:Class ;
+                                                           rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Quality> ;
                                                            rdfs:isDefinedBy """TODO, decide between :
 - The extent to which a piece of information covers different values.
 - The extent to which the domain of the information is constrained.
 - Previous definition: \"Closeness of agreement between indications or measured quantity values obtained by replicate measurements on the same or similar evaluation subjects under specified conditions.\""""@en .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Quality
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Quality> rdf:type owl:Class ;
-                                                         rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#InformationCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Quality
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Quality> rdf:type owl:Class ;
+                                                         rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion> ;
                                                          rdfs:isDefinedBy "Ability to assess the degree of informational quality of the data" .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#ReasoningCriterion
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#ReasoningCriterion> rdf:type owl:Class ;
-                                                                    rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#EvaluationCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion> rdf:type owl:Class ;
+                                                                    rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion> ;
                                                                     rdfs:isDefinedBy "Encompasses criteria directly affecting how an information fusion system transforms its input data into knowledge. It can also be called as process or inference criteria, as it deals with how the uncertainty model performs operations with information." .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#RelevanceToProblem
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#RelevanceToProblem> rdf:type owl:Class ;
-                                                                    rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#InformationCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#RelevanceToProblem
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#RelevanceToProblem> rdf:type owl:Class ;
+                                                                    rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion> ;
                                                                     rdfs:isDefinedBy "Measure the degree to which an evaluation subject has direct bearing on the objectives of the fusion process. " .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#RepresentationCriterion
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#RepresentationCriterion> rdf:type owl:Class ;
-                                                                         rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#EvaluationCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion> rdf:type owl:Class ;
+                                                                         rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion> ;
                                                                          rdfs:isDefinedBy "Encompasses criteria related to how uncertainty is characterized, captured and stored in a manner that can be processed by the fusion system. " .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Scalability
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Scalability> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#ReasoningCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Scalability
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Scalability> rdf:type owl:Class ;
+                                                             rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion> ;
                                                              rdfs:isDefinedBy "Measure of the ability to handle a growing amount of work in a capable manner or its ability to be enlarged to accommodate that growth." .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#SelfConfidence
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#SelfConfidence> rdf:type owl:Class ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#SelfConfidence
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#SelfConfidence> rdf:type owl:Class ;
                                                                 rdfs:subClassOf :SourceCriterion ;
                                                                 rdfs:isDefinedBy "Measure of the evaluation subject's assessment of its own credibility." ;
                                                                 owl:incompatibleWith 4 ;
                                                                 owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Simplicity
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Simplicity> rdf:type owl:Class ;
-                                                            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#RepresentationCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Simplicity
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Simplicity> rdf:type owl:Class ;
+                                                            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion> ;
                                                             rdfs:isDefinedBy "Assesses the information system's ability to execute common operations without requiring deep knowledge about its inner details. " .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Soudness
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Soudness> rdf:type owl:Class ;
-                                                          rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#ReasoningCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Soudness
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Soudness> rdf:type owl:Class ;
+                                                          rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion> ;
                                                           rdfs:comment "Changed name in version 4.0.0: from \"Correctness\" to \"Soundness\"."@en ;
                                                           rdfs:isDefinedBy "The quality of being based on valid reason or good judgement."@en ;
                                                           owl:backwardCompatibleWith 4 ;
                                                           owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Source
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Source> rdf:type owl:Class ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Source
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Source> rdf:type owl:Class ;
                                                         rdfs:comment "A source is the origin of the information."@en .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Throughput
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Throughput> rdf:type owl:Class ;
-                                                            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#PerformanceCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Throughput
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Throughput> rdf:type owl:Class ;
+                                                            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#PerformanceCriterion> ;
                                                             rdfs:isDefinedBy "Measure of the average (and (possibly peak) rate of conversion of inputs to outputs." ;
                                                             owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Timeliness
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Timeliness> rdf:type owl:Class ;
-                                                            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#PerformanceCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Timeliness
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Timeliness> rdf:type owl:Class ;
+                                                            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#PerformanceCriterion> ;
                                                             rdfs:isDefinedBy "Measure of the ability to produce results within a required timeframe." ;
                                                             owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Traceability
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Traceability> rdf:type owl:Class ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Traceability
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Traceability> rdf:type owl:Class ;
                                                               rdfs:subClassOf :InformationHandlingCriterion ;
                                                               rdfs:isDefinedBy "Measure of the ability of a fusion system to provide an accurate and unbroken historical record of its inputs and the chain of operations that led to its conclusions." .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#UncertainEvidence
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#UncertainEvidence> rdf:type owl:Class ;
-                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#InformationCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#UncertainEvidence
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#UncertainEvidence> rdf:type owl:Class ;
+                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion> ;
                                                                    rdfs:comment "Moved as a subclass of InformationCriterion in version 4.0.0." ;
                                                                    rdfs:isDefinedBy "TODO" ;
                                                                    owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#UnreliableEvidence
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#UnreliableEvidence> rdf:type owl:Class ;
-                                                                    rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#UncertainEvidence> .
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#UnreliableEvidence
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#UnreliableEvidence> rdf:type owl:Class ;
+                                                                    rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#UncertainEvidence> .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Veracity
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Veracity> rdf:type owl:Class ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Veracity
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#Veracity> rdf:type owl:Class ;
                                                           rdfs:subClassOf :SourceCriterion ;
                                                           rdfs:isDefinedBy "Measure of the extent to which a source reports what it assesses to be the case." ;
                                                           owl:incompatibleWith 4 ;
                                                           owl:versionInfo "4.0.0" .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#WeightOfInformation
-<http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#WeightOfInformation> rdf:type owl:Class ;
-                                                                     rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#InformationCriterion> ;
+###  http://eturwg.c4i.gmu.edu/ontologies/URREF#WeightOfInformation
+<http://eturwg.c4i.gmu.edu/ontologies/URREF#WeightOfInformation> rdf:type owl:Class ;
+                                                                     rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion> ;
                                                                      rdfs:comment "Renamed from \"WeightOfEvidence\" in version 4.0.0."@en ;
                                                                      rdfs:isDefinedBy "Measure of the degree of impact of an evaluation subject on the result of fusion. " ;
                                                                      owl:backwardCompatibleWith 4 ;
@@ -949,17 +949,17 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 [ rdf:type owl:AllDisjointClasses ;
   owl:members ( :InformationHandlingCriterion
-                <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#InformationCriterion>
-                <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#ReasoningCriterion>
-                <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#RepresentationCriterion>
+                <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion>
+                <http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion>
+                <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion>
               )
 ] .
 
 
 [ rdf:type owl:AllDisjointClasses ;
-  owl:members ( <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#Credibility>
-                <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#RelevanceToProblem>
-                <http://eturwg.c4i.gmu.edu/ontologies/URREF.owl#WeightOfInformation>
+  owl:members ( <http://eturwg.c4i.gmu.edu/ontologies/URREF#Credibility>
+                <http://eturwg.c4i.gmu.edu/ontologies/URREF#RelevanceToProblem>
+                <http://eturwg.c4i.gmu.edu/ontologies/URREF#WeightOfInformation>
               )
 ] .
 

--- a/URREF.ttl
+++ b/URREF.ttl
@@ -34,11 +34,13 @@ v4.0.0: ETURWG""" ;
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#GivesDataInputTo
 :GivesDataInputTo rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf owl:topObjectProperty ;
                   rdfs:domain :Source .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasEvaluationSubject
 :HasEvaluationSubject rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf owl:topObjectProperty ;
                       owl:inverseOf :IsSubjectOfEvaluationIn ;
                       rdfs:domain :EvaluationProcess ;
                       rdfs:range :FusionSystem ,
@@ -49,12 +51,14 @@ v4.0.0: ETURWG""" ;
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasImperfection
 :HasImperfection rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf owl:topObjectProperty ;
                  rdfs:domain :Evidence ;
                  rdfs:range :UncertaintyType .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasSource
 :HasSource rdf:type owl:ObjectProperty ;
+           rdfs:subPropertyOf owl:topObjectProperty ;
            rdfs:domain :DataInput ,
                        :Evidence ;
            rdfs:range :Source .
@@ -63,6 +67,7 @@ v4.0.0: ETURWG""" ;
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasUncertaintySupport
 :HasUncertaintySupport rdf:type owl:ObjectProperty ,
                                 owl:FunctionalProperty ;
+                       rdfs:subPropertyOf owl:topObjectProperty ;
                        rdfs:domain :Evidence ;
                        rdfs:range :UncertaintySupport .
 
@@ -80,12 +85,14 @@ v4.0.0: ETURWG""" ;
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#NatureOfUncertainty
 :NatureOfUncertainty rdf:type owl:ObjectProperty ,
                               owl:FunctionalProperty ;
+                     rdfs:subPropertyOf owl:topObjectProperty ;
                      rdfs:domain :Evidence ;
                      rdfs:range :UncertaintyNature .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#OuputAssessedBy
 :OuputAssessedBy rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf owl:topObjectProperty ;
                  owl:inverseOf :QualityAssesses ;
                  rdfs:domain :DataOutput ;
                  rdfs:range :Quality .
@@ -93,18 +100,21 @@ v4.0.0: ETURWG""" ;
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#QualityAssesses
 :QualityAssesses rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf owl:topObjectProperty ;
                  rdfs:domain :Quality ;
                  rdfs:range :DataOutput .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ReadSource
 :ReadSource rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf owl:topObjectProperty ;
             rdfs:domain :DataProcessingTechnique ;
             rdfs:range :Source .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesTo
 :appliesTo rdf:type owl:ObjectProperty ;
+           rdfs:subPropertyOf owl:topObjectProperty ;
            rdfs:domain :UncertaintyRepresentation ;
            rdfs:range :RepresentationCriterion ;
            rdfs:isDefinedBy "TODO" ;
@@ -140,6 +150,7 @@ v4.0.0: ETURWG""" ;
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#assesses
 :assesses rdf:type owl:ObjectProperty ;
+          rdfs:subPropertyOf owl:topObjectProperty ;
           owl:inverseOf :isAssessedBy ;
           rdfs:domain :Credibility ;
           rdfs:range :DataInput .
@@ -147,6 +158,7 @@ v4.0.0: ETURWG""" ;
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#basedOn
 :basedOn rdf:type owl:ObjectProperty ;
+         rdfs:subPropertyOf owl:topObjectProperty ;
          rdfs:domain :InformationHandlingMethod,
                      :UncertaintyReasoning,
                      :UncertaintyRepresentation ;
@@ -157,6 +169,7 @@ v4.0.0: ETURWG""" ;
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#employs
 :employs rdf:type owl:ObjectProperty ;
+         rdfs:subPropertyOf owl:topObjectProperty ;
          rdfs:domain :EvaluationMeasure ;
          rdfs:range :EvaluationProcess ;
          rdfs:isDefinedBy "TODO" ;
@@ -165,12 +178,14 @@ v4.0.0: ETURWG""" ;
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#hasInformation
 :hasInformation rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf owl:topObjectProperty ;
                 rdfs:domain :DataInput ,
                             :Source .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#impacts
 :impacts rdf:type owl:ObjectProperty ;
+         rdfs:subPropertyOf owl:topObjectProperty ;
          rdfs:domain :InformationCriterion,
                      :SourceCriterion ;
          rdfs:range :WeightOfInformation ;
@@ -180,6 +195,7 @@ v4.0.0: ETURWG""" ;
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#isAssessedBy
 :isAssessedBy rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf owl:topObjectProperty ;
               rdfs:domain :DataInput ;
               rdfs:range :Credibility .
 
@@ -199,12 +215,14 @@ v4.0.0: ETURWG""" ;
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasPieceOfInformation
 :HasPieceOfInformation rdf:type owl:DatatypeProperty ;
+                       rdfs:subPropertyOf owl:topDataProperty ;
                        rdfs:domain :Evidence ;
                        rdfs:range xsd:string .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasUncertanitySupport
 :HasUncertanitySupport rdf:type owl:DatatypeProperty ;
+                       rdfs:subPropertyOf owl:topDataProperty ;
                        rdfs:domain :Evidence ;
                        rdfs:range xsd:string .
 
@@ -218,11 +236,13 @@ v4.0.0: ETURWG""" ;
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#hasCode
 :hasCode rdf:type owl:DatatypeProperty ,
-                  owl:FunctionalProperty .
+                  owl:FunctionalProperty ;
+         rdfs:subPropertyOf owl:topDataProperty .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#usesource
-:usesource rdf:type owl:DatatypeProperty .
+:usesource rdf:type owl:DatatypeProperty ;
+           rdfs:subPropertyOf owl:topDataProperty .
 
 
 #################################################################

--- a/URREF.ttl
+++ b/URREF.ttl
@@ -614,6 +614,7 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InformationHandlingMethod
 :InformationHandlingMethod a owl:Class ;
                            rdfs:label "Information Handling Method" ;
+                           rdfs:subClassOf owl:Thing ;
                            rdfs:isDefinedBy "TODO" ;
                            owl:versionInfo "4.0.0" .
 

--- a/URREF.ttl
+++ b/URREF.ttl
@@ -4,21 +4,21 @@
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@base <http://eturwg.c4i.gmu.edu/files/ontologies/URREF#> .
 
-# TODO: license
 <http://eturwg.c4i.gmu.edu/files/ontologies/URREF> rdf:type owl:Ontology ;
-    rdfs:label "URREF" ;
-    owl:versionIRI <http://eturwg.c4i.gmu.edu/files/ontologies/URREF_4.0.1.owl> ;
-    owl:versionInfo "v4.0.1" ;
-    owl:priorVersion "v4.0.0" ;
-    rdfs:comment """v2a: ETURWG GM40
+                                                    owl:versionIRI <http://eturwg.c4i.gmu.edu/files/ontologies/URREF/4.0.1> ;
+                                                    rdfs:comment """v2a: ETURWG GM40
 v2b: ETURWG GM41
 v2c: ETURWG GM49
 v2d: ETURWG GM55
 v3: ETURWG GM83
 v3a: ETURWG GM90
 v3b: ETURWG GM102 F18 F2F
-v4.0.0: ETURWG""" .
+v4.0.0: ETURWG""" ;
+                                                    rdfs:label "URREF" ;
+                                                    owl:priorVersion "v4.0.0" ;
+                                                    owl:versionInfo "v4.0.1" .
 
 #################################################################
 #    Object Properties
@@ -28,13 +28,13 @@ v4.0.0: ETURWG""" .
 :DerivationOfUncertainty rdf:type owl:ObjectProperty ;
                          rdfs:subPropertyOf owl:topObjectProperty ;
                          rdf:type owl:FunctionalProperty ;
-                         rdfs:domain <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
-                         rdfs:range <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyDerivation> .
+                         rdfs:domain :Evidence ;
+                         rdfs:range :UncertaintyDerivation .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#GivesDataInputTo
 :GivesDataInputTo rdf:type owl:ObjectProperty ;
-                  rdfs:domain <http://eturwg.c4i.gmu.edu/ontologies/URREF#Source> .
+                  rdfs:domain :Source .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasEvaluationSubject
@@ -43,27 +43,27 @@ v4.0.0: ETURWG""" .
                       rdfs:domain :EvaluationProcess ;
                       rdfs:range :FusionSystem ,
                                  :Information ,
-                                 <http://eturwg.c4i.gmu.edu/ontologies/URREF#Source> ,
-                                 <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyTheory> .
+                                 :Source ,
+                                 :UncertaintyTheory .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasImperfection
 :HasImperfection rdf:type owl:ObjectProperty ;
-                 rdfs:domain <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
-                 rdfs:range <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyType> .
+                 rdfs:domain :Evidence ;
+                 rdfs:range :UncertaintyType .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasSource
 :HasSource rdf:type owl:ObjectProperty ;
            rdfs:domain :DataInput ,
-                       <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
-           rdfs:range <http://eturwg.c4i.gmu.edu/ontologies/URREF#Source> .
+                       :Evidence ;
+           rdfs:range :Source .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasUncertaintySupport
 :HasUncertaintySupport rdf:type owl:ObjectProperty ,
                                 owl:FunctionalProperty ;
-                       rdfs:domain <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
+                       rdfs:domain :Evidence ;
                        rdfs:range :UncertaintySupport .
 
 
@@ -72,35 +72,35 @@ v4.0.0: ETURWG""" .
                          rdfs:subPropertyOf owl:topObjectProperty ;
                          rdfs:domain :FusionSystem ,
                                      :Information ,
-                                     <http://eturwg.c4i.gmu.edu/ontologies/URREF#Source> ,
-                                     <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyTheory> ;
+                                     :Source ,
+                                     :UncertaintyTheory ;
                          rdfs:range :EvaluationProcess .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#NatureOfUncertainty
 :NatureOfUncertainty rdf:type owl:ObjectProperty ,
                               owl:FunctionalProperty ;
-                     rdfs:domain <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
-                     rdfs:range <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyNature> .
+                     rdfs:domain :Evidence ;
+                     rdfs:range :UncertaintyNature .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#OuputAssessedBy
 :OuputAssessedBy rdf:type owl:ObjectProperty ;
                  owl:inverseOf :QualityAssesses ;
                  rdfs:domain :DataOutput ;
-                 rdfs:range <http://eturwg.c4i.gmu.edu/ontologies/URREF#Quality> .
+                 rdfs:range :Quality .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#QualityAssesses
 :QualityAssesses rdf:type owl:ObjectProperty ;
-                 rdfs:domain <http://eturwg.c4i.gmu.edu/ontologies/URREF#Quality> ;
+                 rdfs:domain :Quality ;
                  rdfs:range :DataOutput .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ReadSource
 :ReadSource rdf:type owl:ObjectProperty ;
             rdfs:domain :DataProcessingTechnique ;
-            rdfs:range <http://eturwg.c4i.gmu.edu/ontologies/URREF#Source> .
+            rdfs:range :Source .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesTo
@@ -111,7 +111,7 @@ v4.0.0: ETURWG""" .
                        ] ;
            rdfs:range [ rdf:type owl:Restriction ;
                         owl:onProperty :appliesTo ;
-                        owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion>
+                        owl:someValuesFrom :RepresentationCriterion
                       ] ;
            rdfs:isDefinedBy "TODO" ;
            owl:versionInfo "4.0.0" .
@@ -141,7 +141,7 @@ v4.0.0: ETURWG""" .
                                 ] ;
                     rdfs:range [ rdf:type owl:Restriction ;
                                  owl:onProperty :appliesToReasoning ;
-                                 owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion>
+                                 owl:someValuesFrom :ReasoningCriterion
                                ] ;
                     rdfs:isDefinedBy "TODO" ;
                     owl:versionInfo "4.0.0" .
@@ -156,7 +156,7 @@ v4.0.0: ETURWG""" .
                                      ] ;
                          rdfs:range [ rdf:type owl:Restriction ;
                                       owl:onProperty :appliesTo ;
-                                      owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion>
+                                      owl:someValuesFrom :RepresentationCriterion
                                     ] ;
                          rdfs:isDefinedBy "TODO" ;
                          owl:versionInfo "4.0.0" .
@@ -165,7 +165,7 @@ v4.0.0: ETURWG""" .
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#assesses
 :assesses rdf:type owl:ObjectProperty ;
           owl:inverseOf :isAssessedBy ;
-          rdfs:domain <http://eturwg.c4i.gmu.edu/ontologies/URREF#Credibility> ;
+          rdfs:domain :Credibility ;
           rdfs:range :DataInput .
 
 
@@ -208,22 +208,22 @@ v4.0.0: ETURWG""" .
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#hasInformation
 :hasInformation rdf:type owl:ObjectProperty ;
                 rdfs:domain :DataInput ,
-                            <http://eturwg.c4i.gmu.edu/ontologies/URREF#Source> .
+                            :Source .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#impacts
 :impacts rdf:type owl:ObjectProperty ;
          rdfs:domain [ rdf:type owl:Restriction ;
                        owl:onProperty :impacts ;
-                       owl:someValuesFrom :SourceCriterion
+                       owl:someValuesFrom :InformationCriterion
                      ] ,
                      [ rdf:type owl:Restriction ;
                        owl:onProperty :impacts ;
-                       owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion>
+                       owl:someValuesFrom :SourceCriterion
                      ] ;
          rdfs:range [ rdf:type owl:Restriction ;
                       owl:onProperty :impacts ;
-                      owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF#WeightOfInformation>
+                      owl:someValuesFrom :WeightOfInformation
                     ] ;
          rdfs:comment "TODO: decide whether associations are pascalCase or CamelCase."@en ;
          owl:versionInfo "4.0.0" .
@@ -232,7 +232,7 @@ v4.0.0: ETURWG""" .
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#isAssessedBy
 :isAssessedBy rdf:type owl:ObjectProperty ;
               rdfs:domain :DataInput ;
-              rdfs:range <http://eturwg.c4i.gmu.edu/ontologies/URREF#Credibility> .
+              rdfs:range :Credibility .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#measures
@@ -244,7 +244,7 @@ v4.0.0: ETURWG""" .
                       ] ;
           rdfs:range [ rdf:type owl:Restriction ;
                        owl:onProperty :measures ;
-                       owl:someValuesFrom <http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion>
+                       owl:someValuesFrom :EvaluationCriterion
                      ] ;
           rdfs:isDefinedBy "TODO" ;
           owl:versionInfo "4.0.0" .
@@ -256,20 +256,20 @@ v4.0.0: ETURWG""" .
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasPieceOfInformation
 :HasPieceOfInformation rdf:type owl:DatatypeProperty ;
-                       rdfs:domain <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
+                       rdfs:domain :Evidence ;
                        rdfs:range xsd:string .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasUncertanitySupport
 :HasUncertanitySupport rdf:type owl:DatatypeProperty ;
-                       rdfs:domain <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
+                       rdfs:domain :Evidence ;
                        rdfs:range xsd:string .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#TypeOfInformation
 :TypeOfInformation rdf:type owl:DatatypeProperty ;
                    rdfs:subPropertyOf owl:topDataProperty ;
-                   rdfs:domain <http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> ;
+                   rdfs:domain :Evidence ;
                    rdfs:range xsd:string .
 
 
@@ -286,9 +286,32 @@ v4.0.0: ETURWG""" .
 #    Classes
 #################################################################
 
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Accuracy
+:Accuracy rdf:type owl:Class ;
+          rdfs:subClassOf :Quality ;
+          rdfs:isDefinedBy "Closeness of agreement between an evaluation subject value and the true value of the quantity or quality being evaluated." .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Adaptability
+:Adaptability rdf:type owl:Class ;
+              rdfs:subClassOf :RepresentationCriterion ;
+              rdfs:isDefinedBy "Ability of the representational model to allow for different configurations of the model. " .
+
+
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Aleatory
 :Aleatory rdf:type owl:Class ;
-          rdfs:subClassOf <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyNature> .
+          rdfs:subClassOf :UncertaintyNature .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#AmbiguousEvidence
+:AmbiguousEvidence rdf:type owl:Class ;
+                   rdfs:subClassOf :UncertainEvidence .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Assessment
+:Assessment rdf:type owl:Class ;
+            rdfs:subClassOf :Expressiveness ;
+            rdfs:isDefinedBy "Measure of the ability of the system to handle the types of uncertainty assessments (e.g., verbal, quantitative, combined) needed for a given problem, and to distinguish them from one another. " .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Availability
@@ -298,6 +321,12 @@ v4.0.0: ETURWG""" .
               owl:versionInfo "4.0.0" .
 
 
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#BeliefFunctions
+:BeliefFunctions rdf:type owl:Class ;
+                 rdfs:subClassOf :UncertaintyTheory ;
+                 rdfs:comment "Belief functions are closely related to probabilities. Beliefs in a hypothesis is calculated as the sum of the masses of all sets it encloses. A belief function differs from a Bayesian probability model in that one does not condition on those parts of the evidence for which no probabilities are specified. This ability to explicitly model the degree of ignorance makes the theory very appealing and has been applied in areas such as inconsistency handling in OWL ontologies (Nikolov et al., 2007) and ontology mapping (e.g. Yaghlane and Laamari, 2007)."@en .
+
+
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#CommonSenseKnowledge
 :CommonSenseKnowledge rdf:type owl:Class ;
                       rdfs:subClassOf :GenericKnowledge ;
@@ -305,11 +334,26 @@ v4.0.0: ETURWG""" .
                       owl:versionInfo "4.0.0" .
 
 
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Compatibility
+:Compatibility rdf:type owl:Class ;
+               rdfs:subClassOf :RepresentationCriterion ;
+               owl:disjointWith :Expressiveness ;
+               rdfs:isDefinedBy "Measure of how compatible a given knowledge representation is to data standards, and should be related to the degree of flexibility it has in being coded with various standards." .
+
+
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Competency
 :Competency rdf:type owl:Class ;
             rdfs:subClassOf :SourceCriterion ;
             rdfs:isDefinedBy "TODO"@en ;
             owl:versionInfo "4.0.0" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ComputationalCost
+:ComputationalCost rdf:type owl:Class ;
+                   rdfs:subClassOf :PerformanceCriterion ;
+                   rdfs:comment "Moved from \"ReasoningCriterion\" in version 4.0.0." ;
+                   rdfs:isDefinedBy "Measure of how much of the system’s computational resources are required by a given representational technique to produce its results." ;
+                   owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Confidentiality
@@ -321,9 +365,21 @@ v4.0.0: ETURWG""" .
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Configurality
 :Configurality rdf:type owl:Class ;
-               rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> ;
+               rdfs:subClassOf :Expressiveness ;
                rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability of an uncertainty representation to support combining uncertainty about many propositions and/or variables, of different types, with different types of uncertainty.""" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Consistency
+:Consistency rdf:type owl:Class ;
+             rdfs:subClassOf :ReasoningCriterion ;
+             rdfs:isDefinedBy "Measure of the ability of the reasoning process to produce the same results when provided with the same data under the same conditions." .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Credibility
+:Credibility rdf:type owl:Class ;
+             rdfs:subClassOf :InformationCriterion ;
+             rdfs:isDefinedBy "Measure of the degree to which an evaluation subject can be believed or accepted as true, real, or honest." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DataInput
@@ -346,13 +402,23 @@ Ability of an uncertainty representation to support combining uncertainty about 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Dependency
 :Dependency rdf:type owl:Class ;
-            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> ;
+            rdfs:subClassOf :Expressiveness ;
             rdfs:isDefinedBy "Ability of the uncertainty representation to capture dependency among propositions (e.g., cause and effect, relevance, statistical association)." .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DissonantEvidence
+:DissonantEvidence rdf:type owl:Class ;
+                   rdfs:subClassOf :UncertainEvidence .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Epistemic
 :Epistemic rdf:type owl:Class ;
-           rdfs:subClassOf <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyNature> .
+           rdfs:subClassOf :UncertaintyNature .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationCriterion
+:EvaluationCriterion rdf:type owl:Class ;
+                     rdfs:isDefinedBy "Encompasses all the different aspects that must be considered when evaluating uncertainty handling in multi-sensor fusion systems" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationMeasure
@@ -375,11 +441,28 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
                    rdfs:comment "An Evaluation Subject is an item which can be assessed according to the criteria defined in the URREF ontology."@en .
 
 
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Evidence
+:Evidence rdf:type owl:Class ;
+          rdfs:comment "An expression in some logical language that evaluates to a truth-value (formula, axiom, assertion). It is then assumed that information will be presented in the form of sentences. So the uncertainty will be associated with sentences."@en ,
+                       """Evidence, for the purpose of this ontology is considered to be equivalent to:
+- Sentence
+- Information""" ;
+          rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/Uncertainty.owl"^^xsd:anyURI ;
+          owl:deprecated "true"^^xsd:boolean ;
+          owl:versionInfo "4.0.0" .
+
+
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Explainability
 :Explainability rdf:type owl:Class ;
-                rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion> ;
+                rdfs:subClassOf :InformationCriterion ;
                 rdfs:isDefinedBy "TODO" ;
                 owl:versionInfo "4.0.0" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Expressiveness
+:Expressiveness rdf:type owl:Class ;
+                rdfs:subClassOf :RepresentationCriterion ;
+                rdfs:isDefinedBy "Measure of the power of a knowledge representation formalism to convey all relevant aspects of a given fusion problem." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionMethod
@@ -404,6 +487,12 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
                      owl:versionInfo "4.0.0" .
 
 
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FuzzySets
+:FuzzySets rdf:type owl:Class ;
+           rdfs:subClassOf :UncertaintyTheory ;
+           rdfs:comment "In contrast to probabilistic formalisms, which allow for representing and processing degrees of uncertainty about ambiguous pieces of information, fuzzy formalisms allow for representing and processing degrees of truth about vague (or imprecise) pieces of information. It is important to point out that vague statements are truth-functional, that is, the degree of truth of a vague complex statement (which is constructed from elementary vague statements via logical operators) can be calculated from the degrees of truth of its constituents, while uncertain complex statements are generally not a function of the degrees of uncertainty of their constituents (Dubois and Prade, 1994)."@en .
+
+
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#GenericKnowledge
 :GenericKnowledge rdf:type owl:Class ;
                   rdfs:subClassOf :Information ;
@@ -414,18 +503,37 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HigherOrderUncertainty
 :HigherOrderUncertainty rdf:type owl:Class ;
-                        rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> ;
+                        rdfs:subClassOf :Expressiveness ;
                         rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability of the system to represent uncertainty about the uncertainty model, including parameters, structure, and/or type of  model. """ .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#IncompleteEvidence
+:IncompleteEvidence rdf:type owl:Class ;
+                    rdfs:subClassOf :UncertainEvidence .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InconclusiveEvidence
+:InconclusiveEvidence rdf:type owl:Class ;
+                      rdfs:subClassOf :UncertainEvidence .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Information
 :Information rdf:type owl:Class .
 
 
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InformationCriterion
+:InformationCriterion rdf:type owl:Class ;
+                      rdfs:subClassOf :EvaluationCriterion ;
+                      rdfs:comment "Renammed from \"DataCriteron\" as of version 4.0.0."@en ;
+                      rdfs:isDefinedBy "Evaluation Criteria that concern aspects of information and their relationship to source, the object being reported upon, and the objectives of the fusion process."@en ;
+                      owl:incompatibleWith 4 ;
+                      owl:versionInfo "4.0.0" .
+
+
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InformationHandlingCriterion
 :InformationHandlingCriterion rdf:type owl:Class ;
-                              rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion> ;
+                              rdfs:subClassOf :EvaluationCriterion ;
                               rdfs:comment "Renamed from \"DataHandlingCriterion\" in version 4.0.0." ;
                               rdfs:isDefinedBy "Measure of the way data is managed by the fusion system." ;
                               owl:versionInfo "4.0.0" .
@@ -446,14 +554,26 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Interpretability
 :Interpretability rdf:type owl:Class ;
-                  rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion> ;
+                  rdfs:subClassOf :ReasoningCriterion ;
                   rdfs:isDefinedBy "TODO" ;
                   owl:versionInfo "4.0.0" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Interpretation
+:Interpretation rdf:type owl:Class ;
+                owl:deprecated "true"^^xsd:boolean ;
+                owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Interval
 :Interval rdf:type owl:Class ;
           rdfs:subClassOf :TypeOfScale .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#KnowledgeHandling
+:KnowledgeHandling rdf:type owl:Class ;
+                   rdfs:subClassOf :RepresentationCriterion ;
+                   rdfs:isDefinedBy "Measure the ability of a given uncertainty representation technique to convey knowledge."@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#LogicalRule
@@ -470,7 +590,15 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Objective
 :Objective rdf:type owl:Class ;
-           rdfs:subClassOf <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyDerivation> .
+           rdfs:subClassOf :UncertaintyDerivation .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Objectivity
+:Objectivity rdf:type owl:Class ;
+             rdfs:subClassOf :SourceCriterion ;
+             rdfs:isDefinedBy "Measure of the extent to which an evaluation subject reports about a matter of fact in an unbiased manner." ;
+             owl:incompatibleWith 4 ;
+             owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Observation
@@ -482,8 +610,11 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ObservationalSensitivity
 :ObservationalSensitivity rdf:type owl:Class ;
-                          rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Credibility> ;
+                          rdfs:subClassOf :Credibility ,
+                                          :SourceCriterion ;
+                          rdfs:isDefinedBy "Quotient of the change in a result of evaluation subject  and the corresponding change in a value of a quality being observed." ;
                           owl:deprecated "true"^^xsd:boolean ;
+                          owl:incompatibleWith 4 ;
                           owl:versionInfo "4.0.0" .
 
 
@@ -494,9 +625,17 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Outcomes
 :Outcomes rdf:type owl:Class ;
-          rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> ;
+          rdfs:subClassOf :Expressiveness ;
           rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability to represent different kinds of outcomes for uncertain variables, e.g., Boolean, qualitative categorical, ordinal, discrete numerical, continuous.""" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#PerformanceCriterion
+:PerformanceCriterion rdf:type owl:Class ;
+                      rdfs:subClassOf :EvaluationCriterion ;
+                      rdfs:comment "Moved from \"ReasoningCriterion\" and renamed from \"Performance\" in version 4.0.0." ;
+                      rdfs:isDefinedBy "Measure how suitable the representational model is to handle the functional requirements of an information fusion system. Other system architecture factors also affect these metrics." ;
+                      owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#PhysicalRule
@@ -506,16 +645,56 @@ Ability to represent different kinds of outcomes for uncertain variables, e.g., 
               owl:versionInfo "4.0.0" .
 
 
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Precision
+:Precision rdf:type owl:Class ;
+           rdfs:subClassOf :Quality ;
+           rdfs:isDefinedBy """TODO, decide between :
+- The extent to which a piece of information covers different values.
+- The extent to which the domain of the information is constrained.
+- Previous definition: \"Closeness of agreement between indications or measured quantity values obtained by replicate measurements on the same or similar evaluation subjects under specified conditions.\""""@en .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Probability
+:Probability rdf:type owl:Class ;
+             rdfs:subClassOf :UncertaintyTheory ;
+             rdfs:comment "Probability theory provides a mathematically sound representation language and formal calculus for rational degrees of belief, which gives different agents the freedom to have different beliefs about a given hypothesis."@en .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Quality
+:Quality rdf:type owl:Class ;
+         rdfs:subClassOf :InformationCriterion ;
+         rdfs:isDefinedBy "Ability to assess the degree of informational quality of the data" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#RandomSets
+:RandomSets rdf:type owl:Class ;
+            rdfs:subClassOf :UncertaintyTheory ;
+            rdfs:comment "A rough set, first described by a Polish computer scientist Zdzisław I. Pawlak, is a formal approximation of a crisp set (i.e., conventional set) in terms of a pair of sets which give the lower and the upper approximation of the original set. In the standard version of rough set theory (Pawlak 1991), the lower- and upper-approximation sets are crisp sets, but in other variations, the approximating sets may be fuzzy set"@en ;
+            rdfs:isDefinedBy "http://en.wikipedia.org/wiki/Rough_sets"^^xsd:anyURI .
+
+
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Ratio
 :Ratio rdf:type owl:Class ;
        rdfs:subClassOf :TypeOfScale .
 
 
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ReasoningCriterion
+:ReasoningCriterion rdf:type owl:Class ;
+                    rdfs:subClassOf :EvaluationCriterion ;
+                    rdfs:isDefinedBy "Encompasses criteria directly affecting how an information fusion system transforms its input data into knowledge. It can also be called as process or inference criteria, as it deals with how the uncertainty model performs operations with information." .
+
+
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Relational
 :Relational rdf:type owl:Class ;
-            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> ;
+            rdfs:subClassOf :Expressiveness ;
             rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability to represent uncertainty about domains with relational structure, e.g.,   attribute value uncertainty; reference uncertainty; type uncertainty; existence uncertainty.""" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#RelevanceToProblem
+:RelevanceToProblem rdf:type owl:Class ;
+                    rdfs:subClassOf :InformationCriterion ;
+                    rdfs:isDefinedBy "Measure the degree to which an evaluation subject has direct bearing on the objectives of the fusion process. " .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Reliability
@@ -525,11 +704,22 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
              owl:versionInfo "4.0.0" .
 
 
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#RepresentationCriterion
+:RepresentationCriterion rdf:type owl:Class ;
+                         rdfs:subClassOf :EvaluationCriterion ;
+                         rdfs:isDefinedBy "Encompasses criteria related to how uncertainty is characterized, captured and stored in a manner that can be processed by the fusion system. " .
+
+
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Reputation
 :Reputation rdf:type owl:Class ;
             rdfs:subClassOf :SourceCriterion ;
             rdfs:isDefinedBy "TODO"@en ;
             owl:versionInfo "4.0.0" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#RoughSets
+:RoughSets rdf:type owl:Class ;
+           rdfs:subClassOf :UncertaintyTheory .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#STANAG2511
@@ -550,10 +740,19 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
                        owl:deprecated "true"^^xsd:boolean .
 
 
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Scalability
+:Scalability rdf:type owl:Class ;
+             rdfs:subClassOf :ReasoningCriterion ;
+             rdfs:isDefinedBy "Measure of the ability to handle a growing amount of work in a capable manner or its ability to be enlarged to accommodate that growth." .
+
+
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SelfConfidence
 :SelfConfidence rdf:type owl:Class ;
-                rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Credibility> ;
+                rdfs:subClassOf :Credibility ,
+                                :SourceCriterion ;
+                rdfs:isDefinedBy "Measure of the evaluation subject's assessment of its own credibility." ;
                 owl:deprecated "true"^^xsd:boolean ;
+                owl:incompatibleWith 4 ;
                 owl:versionInfo "4.0.0" .
 
 
@@ -564,6 +763,12 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
                    owl:versionInfo "4.0.0" .
 
 
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Simplicity
+:Simplicity rdf:type owl:Class ;
+            rdfs:subClassOf :RepresentationCriterion ;
+            rdfs:isDefinedBy "Assesses the information system's ability to execute common operations without requiring deep knowledge about its inner details. " .
+
+
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SingularEvidence
 :SingularEvidence rdf:type owl:Class ;
                   rdfs:subClassOf :Information ;
@@ -572,9 +777,23 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
                   owl:versionInfo "4.0.0" .
 
 
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Soudness
+:Soudness rdf:type owl:Class ;
+          rdfs:subClassOf :ReasoningCriterion ;
+          rdfs:comment "Changed name in version 4.0.0: from \"Correctness\" to \"Soundness\"."@en ;
+          rdfs:isDefinedBy "The quality of being based on valid reason or good judgement."@en ;
+          owl:backwardCompatibleWith 4 ;
+          owl:versionInfo "4.0.0" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Source
+:Source rdf:type owl:Class ;
+        rdfs:comment "A source is the origin of the information."@en .
+
+
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SourceCriterion
 :SourceCriterion rdf:type owl:Class ;
-                 rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion> ;
+                 rdfs:subClassOf :EvaluationCriterion ;
                  rdfs:isDefinedBy "Any feature of the source which will affect the quality of the information provided by the source."@en ;
                  owl:versionInfo "4.0.0" .
 
@@ -588,7 +807,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Subjective
 :Subjective rdf:type owl:Class ;
-            rdfs:subClassOf <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyDerivation> .
+            rdfs:subClassOf :UncertaintyDerivation .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Testimony
@@ -596,6 +815,26 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
            rdfs:subClassOf :SingularEvidence ;
            rdfs:isDefinedBy "TODO"@en ;
            owl:versionInfo "4.0.0" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Throughput
+:Throughput rdf:type owl:Class ;
+            rdfs:subClassOf :PerformanceCriterion ;
+            rdfs:isDefinedBy "Measure of the average (and (possibly peak) rate of conversion of inputs to outputs." ;
+            owl:versionInfo "4.0.0" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Timeliness
+:Timeliness rdf:type owl:Class ;
+            rdfs:subClassOf :PerformanceCriterion ;
+            rdfs:isDefinedBy "Measure of the ability to produce results within a required timeframe." ;
+            owl:versionInfo "4.0.0" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Traceability
+:Traceability rdf:type owl:Class ;
+              rdfs:subClassOf :InformationHandlingCriterion ;
+              rdfs:isDefinedBy "Measure of the ability of a fusion system to provide an accurate and unbroken historical record of its inputs and the chain of operations that led to its conclusions." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Transparency
@@ -615,6 +854,20 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 :TypeOfScale rdf:type owl:Class .
 
 
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertainEvidence
+:UncertainEvidence rdf:type owl:Class ;
+                   rdfs:subClassOf :InformationCriterion ;
+                   rdfs:comment "Moved as a subclass of InformationCriterion in version 4.0.0." ;
+                   rdfs:isDefinedBy "TODO" ;
+                   owl:versionInfo "4.0.0" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyDerivation
+:UncertaintyDerivation rdf:type owl:Class ;
+                       rdfs:comment "Uncertainty derivation refers to the way it can be assessed. That is, how the uncertainty metrics can be derived."@en ;
+                       rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
+
+
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyModel
 :UncertaintyModel rdf:type owl:Class ;
                   rdfs:comment "Renamed from \"UncertaintyFunction\" in version 4.0.0." ;
@@ -622,6 +875,12 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 - a probability function
 - a support over something""" ;
                   owl:versionInfo "4.0.0" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyNature
+:UncertaintyNature rdf:type owl:Class ;
+                   rdfs:comment "This captures the information about the nature of the uncertainty, i.e., whether the uncertainty is inherent in the phenomenon expressed by the sentence, or it is the result of lack of knowledge of the agent."@en ;
+                   rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyReasoning
@@ -639,308 +898,39 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
                     rdfs:isDefinedBy "TODO: what you are certain about." .
 
 
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Accuracy
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Accuracy> rdf:type owl:Class ;
-                                                          rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Quality> ;
-                                                          rdfs:isDefinedBy "Closeness of agreement between an evaluation subject value and the true value of the quantity or quality being evaluated." .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Adaptability
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Adaptability> rdf:type owl:Class ;
-                                                              rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion> ;
-                                                              rdfs:isDefinedBy "Ability of the representational model to allow for different configurations of the model. " .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#AmbiguousEvidence
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#AmbiguousEvidence> rdf:type owl:Class ;
-                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#UncertainEvidence> .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Assessment
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Assessment> rdf:type owl:Class ;
-                                                            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> ;
-                                                            rdfs:isDefinedBy "Measure of the ability of the system to handle the types of uncertainty assessments (e.g., verbal, quantitative, combined) needed for a given problem, and to distinguish them from one another. " .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Compatibility
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Compatibility> rdf:type owl:Class ;
-                                                               rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion> ;
-                                                               owl:disjointWith <http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> ;
-                                                               rdfs:isDefinedBy "Measure of how compatible a given knowledge representation is to data standards, and should be related to the degree of flexibility it has in being coded with various standards." .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#ComputationalCost
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#ComputationalCost> rdf:type owl:Class ;
-                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#PerformanceCriterion> ;
-                                                                   rdfs:comment "Moved from \"ReasoningCriterion\" in version 4.0.0." ;
-                                                                   rdfs:isDefinedBy "Measure of how much of the system’s computational resources are required by a given representational technique to produce its results." ;
-                                                                   owl:versionInfo "4.0.0" .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Consistency
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Consistency> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion> ;
-                                                             rdfs:isDefinedBy "Measure of the ability of the reasoning process to produce the same results when provided with the same data under the same conditions." .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Credibility
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Credibility> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion> ;
-                                                             rdfs:isDefinedBy "Measure of the degree to which an evaluation subject can be believed or accepted as true, real, or honest." .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#DissonantEvidence
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#DissonantEvidence> rdf:type owl:Class ;
-                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#UncertainEvidence> .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion> rdf:type owl:Class ;
-                                                                     rdfs:isDefinedBy "Encompasses all the different aspects that must be considered when evaluating uncertainty handling in multi-sensor fusion systems" .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Expressiveness> rdf:type owl:Class ;
-                                                                rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion> ;
-                                                                rdfs:isDefinedBy "Measure of the power of a knowledge representation formalism to convey all relevant aspects of a given fusion problem." .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#IncompleteEvidence
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#IncompleteEvidence> rdf:type owl:Class ;
-                                                                    rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#UncertainEvidence> .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#InconclusiveEvidence
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#InconclusiveEvidence> rdf:type owl:Class ;
-                                                                      rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#UncertainEvidence> .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion> rdf:type owl:Class ;
-                                                                      rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion> ;
-                                                                      rdfs:comment "Renammed from \"DataCriteron\" as of version 4.0.0."@en ;
-                                                                      rdfs:isDefinedBy "Evaluation Criteria that concern aspects of information and their relationship to source, the object being reported upon, and the objectives of the fusion process."@en ;
-                                                                      owl:incompatibleWith 4 ;
-                                                                      owl:versionInfo "4.0.0" .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Interpretation
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Interpretation> rdf:type owl:Class ;
-                                                                owl:deprecated "true"^^xsd:boolean ;
-                                                                owl:versionInfo "4.0.0" .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#KnowledgeHandling
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#KnowledgeHandling> rdf:type owl:Class ;
-                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion> ;
-                                                                   rdfs:isDefinedBy "Measure the ability of a given uncertainty representation technique to convey knowledge."@en .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Objectivity
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Objectivity> rdf:type owl:Class ;
-                                                             rdfs:subClassOf :SourceCriterion ;
-                                                             rdfs:isDefinedBy "Measure of the extent to which an evaluation subject reports about a matter of fact in an unbiased manner." ;
-                                                             owl:incompatibleWith 4 ;
-                                                             owl:versionInfo "4.0.0" .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#ObservationalSensitivity
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#ObservationalSensitivity> rdf:type owl:Class ;
-                                                                          rdfs:subClassOf :SourceCriterion ;
-                                                                          rdfs:isDefinedBy "Quotient of the change in a result of evaluation subject  and the corresponding change in a value of a quality being observed." ;
-                                                                          owl:incompatibleWith 4 ;
-                                                                          owl:versionInfo "4.0.0" .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#PerformanceCriterion
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#PerformanceCriterion> rdf:type owl:Class ;
-                                                                      rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion> ;
-                                                                      rdfs:comment "Moved from \"ReasoningCriterion\" and renamed from \"Performance\" in version 4.0.0." ;
-                                                                      rdfs:isDefinedBy "Measure how suitable the representational model is to handle the functional requirements of an information fusion system. Other system architecture factors also affect these metrics." ;
-                                                                      owl:versionInfo "4.0.0" .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Precision
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Precision> rdf:type owl:Class ;
-                                                           rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#Quality> ;
-                                                           rdfs:isDefinedBy """TODO, decide between :
-- The extent to which a piece of information covers different values.
-- The extent to which the domain of the information is constrained.
-- Previous definition: \"Closeness of agreement between indications or measured quantity values obtained by replicate measurements on the same or similar evaluation subjects under specified conditions.\""""@en .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Quality
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Quality> rdf:type owl:Class ;
-                                                         rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion> ;
-                                                         rdfs:isDefinedBy "Ability to assess the degree of informational quality of the data" .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion> rdf:type owl:Class ;
-                                                                    rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion> ;
-                                                                    rdfs:isDefinedBy "Encompasses criteria directly affecting how an information fusion system transforms its input data into knowledge. It can also be called as process or inference criteria, as it deals with how the uncertainty model performs operations with information." .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#RelevanceToProblem
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#RelevanceToProblem> rdf:type owl:Class ;
-                                                                    rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion> ;
-                                                                    rdfs:isDefinedBy "Measure the degree to which an evaluation subject has direct bearing on the objectives of the fusion process. " .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion> rdf:type owl:Class ;
-                                                                         rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#EvaluationCriterion> ;
-                                                                         rdfs:isDefinedBy "Encompasses criteria related to how uncertainty is characterized, captured and stored in a manner that can be processed by the fusion system. " .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Scalability
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Scalability> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion> ;
-                                                             rdfs:isDefinedBy "Measure of the ability to handle a growing amount of work in a capable manner or its ability to be enlarged to accommodate that growth." .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#SelfConfidence
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#SelfConfidence> rdf:type owl:Class ;
-                                                                rdfs:subClassOf :SourceCriterion ;
-                                                                rdfs:isDefinedBy "Measure of the evaluation subject's assessment of its own credibility." ;
-                                                                owl:incompatibleWith 4 ;
-                                                                owl:versionInfo "4.0.0" .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Simplicity
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Simplicity> rdf:type owl:Class ;
-                                                            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion> ;
-                                                            rdfs:isDefinedBy "Assesses the information system's ability to execute common operations without requiring deep knowledge about its inner details. " .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Soudness
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Soudness> rdf:type owl:Class ;
-                                                          rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion> ;
-                                                          rdfs:comment "Changed name in version 4.0.0: from \"Correctness\" to \"Soundness\"."@en ;
-                                                          rdfs:isDefinedBy "The quality of being based on valid reason or good judgement."@en ;
-                                                          owl:backwardCompatibleWith 4 ;
-                                                          owl:versionInfo "4.0.0" .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Source
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Source> rdf:type owl:Class ;
-                                                        rdfs:comment "A source is the origin of the information."@en .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Throughput
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Throughput> rdf:type owl:Class ;
-                                                            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#PerformanceCriterion> ;
-                                                            rdfs:isDefinedBy "Measure of the average (and (possibly peak) rate of conversion of inputs to outputs." ;
-                                                            owl:versionInfo "4.0.0" .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Timeliness
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Timeliness> rdf:type owl:Class ;
-                                                            rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#PerformanceCriterion> ;
-                                                            rdfs:isDefinedBy "Measure of the ability to produce results within a required timeframe." ;
-                                                            owl:versionInfo "4.0.0" .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Traceability
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Traceability> rdf:type owl:Class ;
-                                                              rdfs:subClassOf :InformationHandlingCriterion ;
-                                                              rdfs:isDefinedBy "Measure of the ability of a fusion system to provide an accurate and unbroken historical record of its inputs and the chain of operations that led to its conclusions." .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#UncertainEvidence
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#UncertainEvidence> rdf:type owl:Class ;
-                                                                   rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion> ;
-                                                                   rdfs:comment "Moved as a subclass of InformationCriterion in version 4.0.0." ;
-                                                                   rdfs:isDefinedBy "TODO" ;
-                                                                   owl:versionInfo "4.0.0" .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#UnreliableEvidence
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#UnreliableEvidence> rdf:type owl:Class ;
-                                                                    rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#UncertainEvidence> .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#Veracity
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#Veracity> rdf:type owl:Class ;
-                                                          rdfs:subClassOf :SourceCriterion ;
-                                                          rdfs:isDefinedBy "Measure of the extent to which a source reports what it assesses to be the case." ;
-                                                          owl:incompatibleWith 4 ;
-                                                          owl:versionInfo "4.0.0" .
-
-
-###  http://eturwg.c4i.gmu.edu/ontologies/URREF#WeightOfInformation
-<http://eturwg.c4i.gmu.edu/ontologies/URREF#WeightOfInformation> rdf:type owl:Class ;
-                                                                     rdfs:subClassOf <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion> ;
-                                                                     rdfs:comment "Renamed from \"WeightOfEvidence\" in version 4.0.0."@en ;
-                                                                     rdfs:isDefinedBy "Measure of the degree of impact of an evaluation subject on the result of fusion. " ;
-                                                                     owl:backwardCompatibleWith 4 ;
-                                                                     owl:versionInfo "4.0.0" .
-
-
-###  http://www.owl-ontologies.com/Ontology1181490123.owl#BeliefFunctions
-<http://www.owl-ontologies.com/Ontology1181490123.owl#BeliefFunctions> rdf:type owl:Class ;
-                                                                       rdfs:subClassOf <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyTheory> ;
-                                                                       rdfs:comment "Belief functions are closely related to probabilities. Beliefs in a hypothesis is calculated as the sum of the masses of all sets it encloses. A belief function differs from a Bayesian probability model in that one does not condition on those parts of the evidence for which no probabilities are specified. This ability to explicitly model the degree of ignorance makes the theory very appealing and has been applied in areas such as inconsistency handling in OWL ontologies (Nikolov et al., 2007) and ontology mapping (e.g. Yaghlane and Laamari, 2007)."@en .
-
-
-###  http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence
-<http://www.owl-ontologies.com/Ontology1181490123.owl#Evidence> rdf:type owl:Class ;
-                                                                rdfs:comment "An expression in some logical language that evaluates to a truth-value (formula, axiom, assertion). It is then assumed that information will be presented in the form of sentences. So the uncertainty will be associated with sentences."@en ,
-                                                                             """Evidence, for the purpose of this ontology is considered to be equivalent to:
-- Sentence
-- Information""" ;
-                                                                rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/Uncertainty.owl"^^xsd:anyURI ;
-                                                                owl:deprecated "true"^^xsd:boolean ;
-                                                                owl:versionInfo "4.0.0" .
-
-
-###  http://www.owl-ontologies.com/Ontology1181490123.owl#FuzzySets
-<http://www.owl-ontologies.com/Ontology1181490123.owl#FuzzySets> rdf:type owl:Class ;
-                                                                 rdfs:subClassOf <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyTheory> ;
-                                                                 rdfs:comment "In contrast to probabilistic formalisms, which allow for representing and processing degrees of uncertainty about ambiguous pieces of information, fuzzy formalisms allow for representing and processing degrees of truth about vague (or imprecise) pieces of information. It is important to point out that vague statements are truth-functional, that is, the degree of truth of a vague complex statement (which is constructed from elementary vague statements via logical operators) can be calculated from the degrees of truth of its constituents, while uncertain complex statements are generally not a function of the degrees of uncertainty of their constituents (Dubois and Prade, 1994)."@en .
-
-
-###  http://www.owl-ontologies.com/Ontology1181490123.owl#Probability
-<http://www.owl-ontologies.com/Ontology1181490123.owl#Probability> rdf:type owl:Class ;
-                                                                   rdfs:subClassOf <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyTheory> ;
-                                                                   rdfs:comment "Probability theory provides a mathematically sound representation language and formal calculus for rational degrees of belief, which gives different agents the freedom to have different beliefs about a given hypothesis."@en .
-
-
-###  http://www.owl-ontologies.com/Ontology1181490123.owl#RandomSets
-<http://www.owl-ontologies.com/Ontology1181490123.owl#RandomSets> rdf:type owl:Class ;
-                                                                  rdfs:subClassOf <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyTheory> ;
-                                                                  rdfs:comment "A rough set, first described by a Polish computer scientist Zdzisław I. Pawlak, is a formal approximation of a crisp set (i.e., conventional set) in terms of a pair of sets which give the lower and the upper approximation of the original set. In the standard version of rough set theory (Pawlak 1991), the lower- and upper-approximation sets are crisp sets, but in other variations, the approximating sets may be fuzzy set"@en ;
-                                                                  rdfs:isDefinedBy "http://en.wikipedia.org/wiki/Rough_sets"^^xsd:anyURI .
-
-
-###  http://www.owl-ontologies.com/Ontology1181490123.owl#RoughSets
-<http://www.owl-ontologies.com/Ontology1181490123.owl#RoughSets> rdf:type owl:Class ;
-                                                                 rdfs:subClassOf <http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyTheory> .
-
-
-###  http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyDerivation
-<http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyDerivation> rdf:type owl:Class ;
-                                                                             rdfs:comment "Uncertainty derivation refers to the way it can be assessed. That is, how the uncertainty metrics can be derived."@en ;
-                                                                             rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
-
-
-###  http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyNature
-<http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyNature> rdf:type owl:Class ;
-                                                                         rdfs:comment "This captures the information about the nature of the uncertainty, i.e., whether the uncertainty is inherent in the phenomenon expressed by the sentence, or it is the result of lack of knowledge of the agent."@en ;
-                                                                         rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
-
-
-###  http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyTheory
-<http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyTheory> rdf:type owl:Class ;
-                                                                         rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
-
-
-###  http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyType
-<http://www.owl-ontologies.com/Ontology1181490123.owl#UncertaintyType> rdf:type owl:Class ;
-                                                                       rdfs:comment """For the purposes of this ontology, Uncertainty type is equivalent to:
-- type of imperfection""" ,
-                                                                                    "Uncertainty Type is a concept that focuses on underlying characteristics of the information that make it uncertain. "@en ;
-                                                                       rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyTheory
+:UncertaintyTheory rdf:type owl:Class ;
+                   rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyType
+:UncertaintyType rdf:type owl:Class ;
+                 rdfs:comment "Uncertainty Type is a concept that focuses on underlying characteristics of the information that make it uncertain. "@en ,
+                              """For the purposes of this ontology, Uncertainty type is equivalent to:
+- type of imperfection""" ;
+                 rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UnreliableEvidence
+:UnreliableEvidence rdf:type owl:Class ;
+                    rdfs:subClassOf :UncertainEvidence .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Veracity
+:Veracity rdf:type owl:Class ;
+          rdfs:subClassOf :SourceCriterion ;
+          rdfs:isDefinedBy "Measure of the extent to which a source reports what it assesses to be the case." ;
+          owl:incompatibleWith 4 ;
+          owl:versionInfo "4.0.0" .
+
+
+###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#WeightOfInformation
+:WeightOfInformation rdf:type owl:Class ;
+                     rdfs:subClassOf :InformationCriterion ;
+                     rdfs:comment "Renamed from \"WeightOfEvidence\" in version 4.0.0."@en ;
+                     rdfs:isDefinedBy "Measure of the degree of impact of an evaluation subject on the result of fusion. " ;
+                     owl:backwardCompatibleWith 4 ;
+                     owl:versionInfo "4.0.0" .
 
 
 #################################################################
@@ -948,30 +938,30 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 #################################################################
 
 [ rdf:type owl:AllDisjointClasses ;
-  owl:members ( :InformationHandlingCriterion
-                <http://eturwg.c4i.gmu.edu/ontologies/URREF#InformationCriterion>
-                <http://eturwg.c4i.gmu.edu/ontologies/URREF#ReasoningCriterion>
-                <http://eturwg.c4i.gmu.edu/ontologies/URREF#RepresentationCriterion>
+  owl:members ( :BeliefFunctions
+                :FuzzySets
+                :Probability
+                :RandomSets
+                :RoughSets
               )
 ] .
 
 
 [ rdf:type owl:AllDisjointClasses ;
-  owl:members ( <http://eturwg.c4i.gmu.edu/ontologies/URREF#Credibility>
-                <http://eturwg.c4i.gmu.edu/ontologies/URREF#RelevanceToProblem>
-                <http://eturwg.c4i.gmu.edu/ontologies/URREF#WeightOfInformation>
+  owl:members ( :Credibility
+                :RelevanceToProblem
+                :WeightOfInformation
               )
 ] .
 
 
 [ rdf:type owl:AllDisjointClasses ;
-  owl:members ( <http://www.owl-ontologies.com/Ontology1181490123.owl#BeliefFunctions>
-                <http://www.owl-ontologies.com/Ontology1181490123.owl#FuzzySets>
-                <http://www.owl-ontologies.com/Ontology1181490123.owl#Probability>
-                <http://www.owl-ontologies.com/Ontology1181490123.owl#RandomSets>
-                <http://www.owl-ontologies.com/Ontology1181490123.owl#RoughSets>
+  owl:members ( :InformationCriterion
+                :InformationHandlingCriterion
+                :ReasoningCriterion
+                :RepresentationCriterion
               )
 ] .
 
 
-###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/URREF.ttl
+++ b/URREF.ttl
@@ -381,11 +381,13 @@ Ability of an uncertainty representation to support combining uncertainty about 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationCriterion
 :EvaluationCriterion a owl:Class ;
+                     rdfs:subClassOf owl:Thing ;
                      rdfs:isDefinedBy "Encompasses all the different aspects that must be considered when evaluating uncertainty handling in multi-sensor fusion systems" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationMeasure
 :EvaluationMeasure a owl:Class ;
+                   rdfs:subClassOf owl:Thing ;
                    rdfs:comment "Examples covers: STANAG2511Credibility, STANAG2511Reliability, Shanon entropy..." ,
                                 "TODO: what about quantitative versus qualitiative?" ;
                    rdfs:isDefinedBy "TODO" ;
@@ -394,6 +396,7 @@ Ability of an uncertainty representation to support combining uncertainty about 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationProcess
 :EvaluationProcess a owl:Class ;
+                   rdfs:subClassOf owl:Thing ;
                    rdfs:comment """Entities of the Evaluation class are actual evaluations. 
 According to Patton, Evaluation is a process that critically examines a program. It involves collecting and analyzing information about a program's activities, characteristics, and outcomes. Its purpose is to make judgments about a program, to improve its effectiveness, and/or to inform programming decisions. 
 Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA: Sage Publishers.)."""@en .
@@ -401,11 +404,13 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationSubject
 :EvaluationSubject a owl:Class ;
+                   rdfs:subClassOf owl:Thing ;
                    rdfs:comment "An Evaluation Subject is an item which can be assessed according to the criteria defined in the URREF ontology."@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Evidence
 :Evidence a owl:Class ;
+          rdfs:subClassOf owl:Thing ;
           rdfs:comment "An expression in some logical language that evaluates to a truth-value (formula, axiom, assertion). It is then assumed that information will be presented in the form of sentences. So the uncertainty will be associated with sentences."@en ,
                        """Evidence, for the purpose of this ontology is considered to be equivalent to:
 - Sentence
@@ -430,22 +435,26 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionMethod
 :FusionMethod a owl:Class ;
+             rdfs:subClassOf owl:Thing ;
               rdfs:isDefinedBy "TODO" ;
               owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionSystem
-:FusionSystem a owl:Class .
+:FusionSystem a owl:Class ;
+              rdfs:subClassOf owl:Thing .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionSystemComponent
 :FusionSystemComponent a owl:Class ;
+                       rdfs:subClassOf owl:Thing ;
                        owl:deprecated "true"^^xsd:boolean ;
                        owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionSystemProcess
 :FusionSystemProcess a owl:Class ;
+                     rdfs:subClassOf owl:Thing ;
                      owl:deprecated "true"^^xsd:boolean ;
                      owl:versionInfo "4.0.0" .
 
@@ -482,8 +491,8 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Information
-:Information a owl:Class .
-
+:Information a owl:Class ;
+             rdfs:subClassOf owl:Thing .
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InformationCriterion
 :InformationCriterion a owl:Class ;
@@ -524,6 +533,7 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Interpretation
 :Interpretation a owl:Class ;
+                rdfs:subClassOf owl:Thing ;
                 owl:deprecated "true"^^xsd:boolean ;
                 owl:versionInfo "4.0.0" .
 
@@ -751,6 +761,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Source
 :Source a owl:Class ;
+        rdfs:subClassOf owl:Thing ;
         rdfs:comment "A source is the origin of the information."@en .
 
 
@@ -809,12 +820,14 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Trust
 :Trust a owl:Class ;
+       rdfs:subClassOf owl:Thing ;
        rdfs:isDefinedBy "TODO: placeholder to import trust ontologies" ;
        owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#TypeOfScale
-:TypeOfScale a owl:Class .
+:TypeOfScale a owl:Class ;
+             rdfs:subClassOf owl:Thing .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertainEvidence
@@ -827,12 +840,14 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyDerivation
 :UncertaintyDerivation a owl:Class ;
+                       rdfs:subClassOf owl:Thing ;
                        rdfs:comment "Uncertainty derivation refers to the way it can be assessed. That is, how the uncertainty metrics can be derived."@en ;
                        rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyModel
 :UncertaintyModel a owl:Class ;
+                  rdfs:subClassOf owl:Thing ;
                   rdfs:comment "Renamed from \"UncertaintyFunction\" in version 4.0.0." ;
                   rdfs:isDefinedBy """TODO:
 - a probability function
@@ -842,32 +857,38 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyNature
 :UncertaintyNature a owl:Class ;
+                   rdfs:subClassOf owl:Thing ;
                    rdfs:comment "This captures the information about the nature of the uncertainty, i.e., whether the uncertainty is inherent in the phenomenon expressed by the sentence, or it is the result of lack of knowledge of the agent."@en ;
                    rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyReasoning
 :UncertaintyReasoning a owl:Class ;
+                      rdfs:subClassOf owl:Thing ;
                       rdfs:isDefinedBy "TODO" ;
                       owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyRepresentation
-:UncertaintyRepresentation a owl:Class .
+:UncertaintyRepresentation a owl:Class ;
+                           rdfs:subClassOf owl:Thing .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintySupport
 :UncertaintySupport a owl:Class ;
+                    rdfs:subClassOf owl:Thing ;
                     rdfs:isDefinedBy "TODO: what you are certain about." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyTheory
 :UncertaintyTheory a owl:Class ;
+                   rdfs:subClassOf owl:Thing ;
                    rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyType
 :UncertaintyType a owl:Class ;
+                 rdfs:subClassOf owl:Thing ;
                  rdfs:comment "Uncertainty Type is a concept that focuses on underlying characteristics of the information that make it uncertain. "@en ,
                               """For the purposes of this ontology, Uncertainty type is equivalent to:
 - type of imperfection""" ;
@@ -876,6 +897,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UnreliableEvidence
 :UnreliableEvidence a owl:Class ;
+                    rdfs:subClassOf owl:Thing ;
                     rdfs:subClassOf :UncertainEvidence .
 
 

--- a/URREF.ttl
+++ b/URREF.ttl
@@ -6,8 +6,8 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @base <http://eturwg.c4i.gmu.edu/files/ontologies/URREF#> .
 
-<http://eturwg.c4i.gmu.edu/files/ontologies/URREF> rdf:type owl:Ontology ;
-                                                    owl:versionIRI <http://eturwg.c4i.gmu.edu/files/ontologies/URREF/4.0.1> ;
+<http://eturwg.c4i.gmu.edu/files/ontologies/URREF> a owl:Ontology ;
+                                                    owl:versionIRI <http://eturwg.c4i.gmu.edu/files/ontologies/URREF/4.0.1/URREF> ;
                                                     rdfs:comment """v2a: ETURWG GM40
 v2b: ETURWG GM41
 v2c: ETURWG GM49
@@ -25,21 +25,21 @@ v4.0.0: ETURWG""" ;
 #################################################################
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DerivationOfUncertainty
-:DerivationOfUncertainty rdf:type owl:ObjectProperty ;
+:DerivationOfUncertainty a owl:ObjectProperty ;
                          rdfs:subPropertyOf owl:topObjectProperty ;
-                         rdf:type owl:FunctionalProperty ;
+                         a owl:FunctionalProperty ;
                          rdfs:domain :Evidence ;
                          rdfs:range :UncertaintyDerivation .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#GivesDataInputTo
-:GivesDataInputTo rdf:type owl:ObjectProperty ;
+:GivesDataInputTo a owl:ObjectProperty ;
                   rdfs:subPropertyOf owl:topObjectProperty ;
                   rdfs:domain :Source .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasEvaluationSubject
-:HasEvaluationSubject rdf:type owl:ObjectProperty ;
+:HasEvaluationSubject a owl:ObjectProperty ;
                       rdfs:subPropertyOf owl:topObjectProperty ;
                       owl:inverseOf :IsSubjectOfEvaluationIn ;
                       rdfs:domain :EvaluationProcess ;
@@ -50,14 +50,14 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasImperfection
-:HasImperfection rdf:type owl:ObjectProperty ;
+:HasImperfection a owl:ObjectProperty ;
                  rdfs:subPropertyOf owl:topObjectProperty ;
                  rdfs:domain :Evidence ;
                  rdfs:range :UncertaintyType .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasSource
-:HasSource rdf:type owl:ObjectProperty ;
+:HasSource a owl:ObjectProperty ;
            rdfs:subPropertyOf owl:topObjectProperty ;
            rdfs:domain :DataInput ,
                        :Evidence ;
@@ -65,7 +65,7 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasUncertaintySupport
-:HasUncertaintySupport rdf:type owl:ObjectProperty ,
+:HasUncertaintySupport a owl:ObjectProperty ,
                                 owl:FunctionalProperty ;
                        rdfs:subPropertyOf owl:topObjectProperty ;
                        rdfs:domain :Evidence ;
@@ -73,7 +73,7 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#IsSubjectOfEvaluationIn
-:IsSubjectOfEvaluationIn rdf:type owl:ObjectProperty ;
+:IsSubjectOfEvaluationIn a owl:ObjectProperty ;
                          rdfs:subPropertyOf owl:topObjectProperty ;
                          rdfs:domain :FusionSystem ,
                                      :Information ,
@@ -83,7 +83,7 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#NatureOfUncertainty
-:NatureOfUncertainty rdf:type owl:ObjectProperty ,
+:NatureOfUncertainty a owl:ObjectProperty ,
                               owl:FunctionalProperty ;
                      rdfs:subPropertyOf owl:topObjectProperty ;
                      rdfs:domain :Evidence ;
@@ -91,7 +91,7 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#OuputAssessedBy
-:OuputAssessedBy rdf:type owl:ObjectProperty ;
+:OuputAssessedBy a owl:ObjectProperty ;
                  rdfs:subPropertyOf owl:topObjectProperty ;
                  owl:inverseOf :QualityAssesses ;
                  rdfs:domain :DataOutput ;
@@ -99,21 +99,21 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#QualityAssesses
-:QualityAssesses rdf:type owl:ObjectProperty ;
+:QualityAssesses a owl:ObjectProperty ;
                  rdfs:subPropertyOf owl:topObjectProperty ;
                  rdfs:domain :Quality ;
                  rdfs:range :DataOutput .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ReadSource
-:ReadSource rdf:type owl:ObjectProperty ;
+:ReadSource a owl:ObjectProperty ;
             rdfs:subPropertyOf owl:topObjectProperty ;
             rdfs:domain :DataProcessingTechnique ;
             rdfs:range :Source .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesTo
-:appliesTo rdf:type owl:ObjectProperty ;
+:appliesTo a owl:ObjectProperty ;
            rdfs:subPropertyOf owl:topObjectProperty ;
            rdfs:domain :UncertaintyRepresentation ;
            rdfs:range :RepresentationCriterion ;
@@ -122,7 +122,7 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesToHandling
-:appliesToHandling rdf:type owl:ObjectProperty ;
+:appliesToHandling a owl:ObjectProperty ;
                    rdfs:subPropertyOf :appliesTo ;
                    rdfs:domain :InformationHandlingMethod ;
                    rdfs:range :InformationHandlingCriterion ;
@@ -131,7 +131,7 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesToReasoning
-:appliesToReasoning rdf:type owl:ObjectProperty ;
+:appliesToReasoning a owl:ObjectProperty ;
                     rdfs:subPropertyOf :appliesTo ;
                     rdfs:domain :UncertaintyReasoning ;
                     rdfs:range :ReasoningCriterion ;
@@ -140,7 +140,7 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#appliesToRepresentation
-:appliesToRepresentation rdf:type owl:ObjectProperty ;
+:appliesToRepresentation a owl:ObjectProperty ;
                          rdfs:subPropertyOf :appliesTo ;
                          rdfs:domain :UncertaintyRepresentation ;
                          rdfs:range :RepresentationCriterion ;
@@ -149,7 +149,7 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#assesses
-:assesses rdf:type owl:ObjectProperty ;
+:assesses a owl:ObjectProperty ;
           rdfs:subPropertyOf owl:topObjectProperty ;
           owl:inverseOf :isAssessedBy ;
           rdfs:domain :Credibility ;
@@ -157,7 +157,7 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#basedOn
-:basedOn rdf:type owl:ObjectProperty ;
+:basedOn a owl:ObjectProperty ;
          rdfs:subPropertyOf owl:topObjectProperty ;
          rdfs:domain :InformationHandlingMethod,
                      :UncertaintyReasoning,
@@ -168,7 +168,7 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#employs
-:employs rdf:type owl:ObjectProperty ;
+:employs a owl:ObjectProperty ;
          rdfs:subPropertyOf owl:topObjectProperty ;
          rdfs:domain :EvaluationMeasure ;
          rdfs:range :EvaluationProcess ;
@@ -177,14 +177,14 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#hasInformation
-:hasInformation rdf:type owl:ObjectProperty ;
+:hasInformation a owl:ObjectProperty ;
                 rdfs:subPropertyOf owl:topObjectProperty ;
                 rdfs:domain :DataInput ,
                             :Source .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#impacts
-:impacts rdf:type owl:ObjectProperty ;
+:impacts a owl:ObjectProperty ;
          rdfs:subPropertyOf owl:topObjectProperty ;
          rdfs:domain :InformationCriterion,
                      :SourceCriterion ;
@@ -194,14 +194,14 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#isAssessedBy
-:isAssessedBy rdf:type owl:ObjectProperty ;
+:isAssessedBy a owl:ObjectProperty ;
               rdfs:subPropertyOf owl:topObjectProperty ;
               rdfs:domain :DataInput ;
               rdfs:range :Credibility .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#measures
-:measures rdf:type owl:ObjectProperty ;
+:measures a owl:ObjectProperty ;
           rdfs:subPropertyOf owl:topObjectProperty ;
           rdfs:domain :EvaluationMeasure ;
           rdfs:range :EvaluationCriterion ;
@@ -214,34 +214,34 @@ v4.0.0: ETURWG""" ;
 #################################################################
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasPieceOfInformation
-:HasPieceOfInformation rdf:type owl:DatatypeProperty ;
+:HasPieceOfInformation a owl:DatatypeProperty ;
                        rdfs:subPropertyOf owl:topDataProperty ;
                        rdfs:domain :Evidence ;
                        rdfs:range xsd:string .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HasUncertanitySupport
-:HasUncertanitySupport rdf:type owl:DatatypeProperty ;
+:HasUncertanitySupport a owl:DatatypeProperty ;
                        rdfs:subPropertyOf owl:topDataProperty ;
                        rdfs:domain :Evidence ;
                        rdfs:range xsd:string .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#TypeOfInformation
-:TypeOfInformation rdf:type owl:DatatypeProperty ;
+:TypeOfInformation a owl:DatatypeProperty ;
                    rdfs:subPropertyOf owl:topDataProperty ;
                    rdfs:domain :Evidence ;
                    rdfs:range xsd:string .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#hasCode
-:hasCode rdf:type owl:DatatypeProperty ,
+:hasCode a owl:DatatypeProperty ,
                   owl:FunctionalProperty ;
          rdfs:subPropertyOf owl:topDataProperty .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#usesource
-:usesource rdf:type owl:DatatypeProperty ;
+:usesource a owl:DatatypeProperty ;
            rdfs:subPropertyOf owl:topDataProperty .
 
 
@@ -250,69 +250,69 @@ v4.0.0: ETURWG""" ;
 #################################################################
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Accuracy
-:Accuracy rdf:type owl:Class ;
+:Accuracy a owl:Class ;
           rdfs:subClassOf :Quality ;
           rdfs:isDefinedBy "Closeness of agreement between an evaluation subject value and the true value of the quantity or quality being evaluated." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Adaptability
-:Adaptability rdf:type owl:Class ;
+:Adaptability a owl:Class ;
               rdfs:subClassOf :RepresentationCriterion ;
               rdfs:isDefinedBy "Ability of the representational model to allow for different configurations of the model. " .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Aleatory
-:Aleatory rdf:type owl:Class ;
+:Aleatory a owl:Class ;
           rdfs:subClassOf :UncertaintyNature .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#AmbiguousEvidence
-:AmbiguousEvidence rdf:type owl:Class ;
+:AmbiguousEvidence a owl:Class ;
                    rdfs:subClassOf :UncertainEvidence .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Assessment
-:Assessment rdf:type owl:Class ;
+:Assessment a owl:Class ;
             rdfs:subClassOf :Expressiveness ;
             rdfs:isDefinedBy "Measure of the ability of the system to handle the types of uncertainty assessments (e.g., verbal, quantitative, combined) needed for a given problem, and to distinguish them from one another. " .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Availability
-:Availability rdf:type owl:Class ;
+:Availability a owl:Class ;
               rdfs:subClassOf :InformationHandlingCriterion ;
               rdfs:isDefinedBy "TODO" ;
               owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#BeliefFunctions
-:BeliefFunctions rdf:type owl:Class ;
+:BeliefFunctions a owl:Class ;
                  rdfs:subClassOf :UncertaintyTheory ;
                  rdfs:comment "Belief functions are closely related to probabilities. Beliefs in a hypothesis is calculated as the sum of the masses of all sets it encloses. A belief function differs from a Bayesian probability model in that one does not condition on those parts of the evidence for which no probabilities are specified. This ability to explicitly model the degree of ignorance makes the theory very appealing and has been applied in areas such as inconsistency handling in OWL ontologies (Nikolov et al., 2007) and ontology mapping (e.g. Yaghlane and Laamari, 2007)."@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#CommonSenseKnowledge
-:CommonSenseKnowledge rdf:type owl:Class ;
+:CommonSenseKnowledge a owl:Class ;
                       rdfs:subClassOf :GenericKnowledge ;
                       rdfs:isDefinedBy "TODO"@en ;
                       owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Compatibility
-:Compatibility rdf:type owl:Class ;
+:Compatibility a owl:Class ;
                rdfs:subClassOf :RepresentationCriterion ;
                owl:disjointWith :Expressiveness ;
                rdfs:isDefinedBy "Measure of how compatible a given knowledge representation is to data standards, and should be related to the degree of flexibility it has in being coded with various standards." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Competency
-:Competency rdf:type owl:Class ;
+:Competency a owl:Class ;
             rdfs:subClassOf :SourceCriterion ;
             rdfs:isDefinedBy "TODO"@en ;
             owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ComputationalCost
-:ComputationalCost rdf:type owl:Class ;
+:ComputationalCost a owl:Class ;
                    rdfs:subClassOf :PerformanceCriterion ;
                    rdfs:comment "Moved from \"ReasoningCriterion\" in version 4.0.0." ;
                    rdfs:isDefinedBy "Measure of how much of the system’s computational resources are required by a given representational technique to produce its results." ;
@@ -320,72 +320,72 @@ v4.0.0: ETURWG""" ;
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Confidentiality
-:Confidentiality rdf:type owl:Class ;
+:Confidentiality a owl:Class ;
                  rdfs:subClassOf :InformationHandlingCriterion ;
                  rdfs:isDefinedBy "TODO" ;
                  owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Configurality
-:Configurality rdf:type owl:Class ;
+:Configurality a owl:Class ;
                rdfs:subClassOf :Expressiveness ;
                rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability of an uncertainty representation to support combining uncertainty about many propositions and/or variables, of different types, with different types of uncertainty.""" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Consistency
-:Consistency rdf:type owl:Class ;
+:Consistency a owl:Class ;
              rdfs:subClassOf :ReasoningCriterion ;
              rdfs:isDefinedBy "Measure of the ability of the reasoning process to produce the same results when provided with the same data under the same conditions." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Credibility
-:Credibility rdf:type owl:Class ;
+:Credibility a owl:Class ;
              rdfs:subClassOf :InformationCriterion ;
              rdfs:isDefinedBy "Measure of the degree to which an evaluation subject can be believed or accepted as true, real, or honest." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DataInput
-:DataInput rdf:type owl:Class ;
+:DataInput a owl:Class ;
            rdfs:subClassOf :FusionSystem ;
            owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DataOutput
-:DataOutput rdf:type owl:Class ;
+:DataOutput a owl:Class ;
             rdfs:subClassOf :FusionSystem ;
             owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DataProcessingTechnique
-:DataProcessingTechnique rdf:type owl:Class ;
+:DataProcessingTechnique a owl:Class ;
                          rdfs:subClassOf :FusionSystem ;
                          owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Dependency
-:Dependency rdf:type owl:Class ;
+:Dependency a owl:Class ;
             rdfs:subClassOf :Expressiveness ;
             rdfs:isDefinedBy "Ability of the uncertainty representation to capture dependency among propositions (e.g., cause and effect, relevance, statistical association)." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#DissonantEvidence
-:DissonantEvidence rdf:type owl:Class ;
+:DissonantEvidence a owl:Class ;
                    rdfs:subClassOf :UncertainEvidence .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Epistemic
-:Epistemic rdf:type owl:Class ;
+:Epistemic a owl:Class ;
            rdfs:subClassOf :UncertaintyNature .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationCriterion
-:EvaluationCriterion rdf:type owl:Class ;
+:EvaluationCriterion a owl:Class ;
                      rdfs:isDefinedBy "Encompasses all the different aspects that must be considered when evaluating uncertainty handling in multi-sensor fusion systems" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationMeasure
-:EvaluationMeasure rdf:type owl:Class ;
+:EvaluationMeasure a owl:Class ;
                    rdfs:comment "Examples covers: STANAG2511Credibility, STANAG2511Reliability, Shanon entropy..." ,
                                 "TODO: what about quantitative versus qualitiative?" ;
                    rdfs:isDefinedBy "TODO" ;
@@ -393,19 +393,19 @@ Ability of an uncertainty representation to support combining uncertainty about 
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationProcess
-:EvaluationProcess rdf:type owl:Class ;
+:EvaluationProcess a owl:Class ;
                    rdfs:comment """Entities of the Evaluation class are actual evaluations. 
 According to Patton, Evaluation is a process that critically examines a program. It involves collecting and analyzing information about a program's activities, characteristics, and outcomes. Its purpose is to make judgments about a program, to improve its effectiveness, and/or to inform programming decisions. 
 Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA: Sage Publishers.)."""@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#EvaluationSubject
-:EvaluationSubject rdf:type owl:Class ;
+:EvaluationSubject a owl:Class ;
                    rdfs:comment "An Evaluation Subject is an item which can be assessed according to the criteria defined in the URREF ontology."@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Evidence
-:Evidence rdf:type owl:Class ;
+:Evidence a owl:Class ;
           rdfs:comment "An expression in some logical language that evaluates to a truth-value (formula, axiom, assertion). It is then assumed that information will be presented in the form of sentences. So the uncertainty will be associated with sentences."@en ,
                        """Evidence, for the purpose of this ontology is considered to be equivalent to:
 - Sentence
@@ -416,48 +416,48 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Explainability
-:Explainability rdf:type owl:Class ;
+:Explainability a owl:Class ;
                 rdfs:subClassOf :InformationCriterion ;
                 rdfs:isDefinedBy "TODO" ;
                 owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Expressiveness
-:Expressiveness rdf:type owl:Class ;
+:Expressiveness a owl:Class ;
                 rdfs:subClassOf :RepresentationCriterion ;
                 rdfs:isDefinedBy "Measure of the power of a knowledge representation formalism to convey all relevant aspects of a given fusion problem." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionMethod
-:FusionMethod rdf:type owl:Class ;
+:FusionMethod a owl:Class ;
               rdfs:isDefinedBy "TODO" ;
               owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionSystem
-:FusionSystem rdf:type owl:Class .
+:FusionSystem a owl:Class .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionSystemComponent
-:FusionSystemComponent rdf:type owl:Class ;
+:FusionSystemComponent a owl:Class ;
                        owl:deprecated "true"^^xsd:boolean ;
                        owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FusionSystemProcess
-:FusionSystemProcess rdf:type owl:Class ;
+:FusionSystemProcess a owl:Class ;
                      owl:deprecated "true"^^xsd:boolean ;
                      owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#FuzzySets
-:FuzzySets rdf:type owl:Class ;
+:FuzzySets a owl:Class ;
            rdfs:subClassOf :UncertaintyTheory ;
            rdfs:comment "In contrast to probabilistic formalisms, which allow for representing and processing degrees of uncertainty about ambiguous pieces of information, fuzzy formalisms allow for representing and processing degrees of truth about vague (or imprecise) pieces of information. It is important to point out that vague statements are truth-functional, that is, the degree of truth of a vague complex statement (which is constructed from elementary vague statements via logical operators) can be calculated from the degrees of truth of its constituents, while uncertain complex statements are generally not a function of the degrees of uncertainty of their constituents (Dubois and Prade, 1994)."@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#GenericKnowledge
-:GenericKnowledge rdf:type owl:Class ;
+:GenericKnowledge a owl:Class ;
                   rdfs:subClassOf :Information ;
                   rdfs:isDefinedBy "TODO"@en ;
                   rdfs:seeAlso "TODO: ref (ChatGPT paper)" ;
@@ -465,28 +465,28 @@ Patton, M.Q. (1987). Qualitative Research Evaluation Methods. Thousand Oaks, CA:
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#HigherOrderUncertainty
-:HigherOrderUncertainty rdf:type owl:Class ;
+:HigherOrderUncertainty a owl:Class ;
                         rdfs:subClassOf :Expressiveness ;
                         rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability of the system to represent uncertainty about the uncertainty model, including parameters, structure, and/or type of  model. """ .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#IncompleteEvidence
-:IncompleteEvidence rdf:type owl:Class ;
+:IncompleteEvidence a owl:Class ;
                     rdfs:subClassOf :UncertainEvidence .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InconclusiveEvidence
-:InconclusiveEvidence rdf:type owl:Class ;
+:InconclusiveEvidence a owl:Class ;
                       rdfs:subClassOf :UncertainEvidence .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Information
-:Information rdf:type owl:Class .
+:Information a owl:Class .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InformationCriterion
-:InformationCriterion rdf:type owl:Class ;
+:InformationCriterion a owl:Class ;
                       rdfs:subClassOf :EvaluationCriterion ;
                       rdfs:comment "Renammed from \"DataCriteron\" as of version 4.0.0."@en ;
                       rdfs:isDefinedBy "Evaluation Criteria that concern aspects of information and their relationship to source, the object being reported upon, and the objectives of the fusion process."@en ;
@@ -495,7 +495,7 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InformationHandlingCriterion
-:InformationHandlingCriterion rdf:type owl:Class ;
+:InformationHandlingCriterion a owl:Class ;
                               rdfs:subClassOf :EvaluationCriterion ;
                               rdfs:comment "Renamed from \"DataHandlingCriterion\" in version 4.0.0." ;
                               rdfs:isDefinedBy "Measure of the way data is managed by the fusion system." ;
@@ -503,61 +503,61 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#InformationHandlingMethod
-:InformationHandlingMethod rdf:type owl:Class ;
+:InformationHandlingMethod a owl:Class ;
                            rdfs:isDefinedBy "TODO" ;
                            owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Integrity
-:Integrity rdf:type owl:Class ;
+:Integrity a owl:Class ;
            rdfs:subClassOf :InformationHandlingCriterion ;
            rdfs:isDefinedBy "TODO" ;
            owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Interpretability
-:Interpretability rdf:type owl:Class ;
+:Interpretability a owl:Class ;
                   rdfs:subClassOf :ReasoningCriterion ;
                   rdfs:isDefinedBy "TODO" ;
                   owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Interpretation
-:Interpretation rdf:type owl:Class ;
+:Interpretation a owl:Class ;
                 owl:deprecated "true"^^xsd:boolean ;
                 owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Interval
-:Interval rdf:type owl:Class ;
+:Interval a owl:Class ;
           rdfs:subClassOf :TypeOfScale .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#KnowledgeHandling
-:KnowledgeHandling rdf:type owl:Class ;
+:KnowledgeHandling a owl:Class ;
                    rdfs:subClassOf :RepresentationCriterion ;
                    rdfs:isDefinedBy "Measure the ability of a given uncertainty representation technique to convey knowledge."@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#LogicalRule
-:LogicalRule rdf:type owl:Class ;
+:LogicalRule a owl:Class ;
              rdfs:subClassOf :GenericKnowledge ;
              rdfs:isDefinedBy "TODO"@en ;
              owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Nominal
-:Nominal rdf:type owl:Class ;
+:Nominal a owl:Class ;
          rdfs:subClassOf :TypeOfScale .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Objective
-:Objective rdf:type owl:Class ;
+:Objective a owl:Class ;
            rdfs:subClassOf :UncertaintyDerivation .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Objectivity
-:Objectivity rdf:type owl:Class ;
+:Objectivity a owl:Class ;
              rdfs:subClassOf :SourceCriterion ;
              rdfs:isDefinedBy "Measure of the extent to which an evaluation subject reports about a matter of fact in an unbiased manner." ;
              owl:incompatibleWith 4 ;
@@ -565,14 +565,14 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Observation
-:Observation rdf:type owl:Class ;
+:Observation a owl:Class ;
              rdfs:subClassOf :SingularEvidence ;
              rdfs:isDefinedBy "TODO"@en ;
              owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ObservationalSensitivity
-:ObservationalSensitivity rdf:type owl:Class ;
+:ObservationalSensitivity a owl:Class ;
                           rdfs:subClassOf :Credibility ,
                                           :SourceCriterion ;
                           rdfs:isDefinedBy "Quotient of the change in a result of evaluation subject  and the corresponding change in a value of a quality being observed." ;
@@ -582,19 +582,19 @@ Ability of the system to represent uncertainty about the uncertainty model, incl
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Ordinal
-:Ordinal rdf:type owl:Class ;
+:Ordinal a owl:Class ;
          rdfs:subClassOf :TypeOfScale .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Outcomes
-:Outcomes rdf:type owl:Class ;
+:Outcomes a owl:Class ;
           rdfs:subClassOf :Expressiveness ;
           rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability to represent different kinds of outcomes for uncertain variables, e.g., Boolean, qualitative categorical, ordinal, discrete numerical, continuous.""" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#PerformanceCriterion
-:PerformanceCriterion rdf:type owl:Class ;
+:PerformanceCriterion a owl:Class ;
                       rdfs:subClassOf :EvaluationCriterion ;
                       rdfs:comment "Moved from \"ReasoningCriterion\" and renamed from \"Performance\" in version 4.0.0." ;
                       rdfs:isDefinedBy "Measure how suitable the representational model is to handle the functional requirements of an information fusion system. Other system architecture factors also affect these metrics." ;
@@ -602,14 +602,14 @@ Ability to represent different kinds of outcomes for uncertain variables, e.g., 
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#PhysicalRule
-:PhysicalRule rdf:type owl:Class ;
+:PhysicalRule a owl:Class ;
               rdfs:subClassOf :GenericKnowledge ;
               rdfs:isDefinedBy "TODO"@en ;
               owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Precision
-:Precision rdf:type owl:Class ;
+:Precision a owl:Class ;
            rdfs:subClassOf :Quality ;
            rdfs:isDefinedBy """TODO, decide between :
 - The extent to which a piece of information covers different values.
@@ -618,99 +618,99 @@ Ability to represent different kinds of outcomes for uncertain variables, e.g., 
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Probability
-:Probability rdf:type owl:Class ;
+:Probability a owl:Class ;
              rdfs:subClassOf :UncertaintyTheory ;
              rdfs:comment "Probability theory provides a mathematically sound representation language and formal calculus for rational degrees of belief, which gives different agents the freedom to have different beliefs about a given hypothesis."@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Quality
-:Quality rdf:type owl:Class ;
+:Quality a owl:Class ;
          rdfs:subClassOf :InformationCriterion ;
          rdfs:isDefinedBy "Ability to assess the degree of informational quality of the data" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#RandomSets
-:RandomSets rdf:type owl:Class ;
+:RandomSets a owl:Class ;
             rdfs:subClassOf :UncertaintyTheory ;
             rdfs:comment "A rough set, first described by a Polish computer scientist Zdzisław I. Pawlak, is a formal approximation of a crisp set (i.e., conventional set) in terms of a pair of sets which give the lower and the upper approximation of the original set. In the standard version of rough set theory (Pawlak 1991), the lower- and upper-approximation sets are crisp sets, but in other variations, the approximating sets may be fuzzy set"@en ;
             rdfs:isDefinedBy "http://en.wikipedia.org/wiki/Rough_sets"^^xsd:anyURI .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Ratio
-:Ratio rdf:type owl:Class ;
+:Ratio a owl:Class ;
        rdfs:subClassOf :TypeOfScale .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#ReasoningCriterion
-:ReasoningCriterion rdf:type owl:Class ;
+:ReasoningCriterion a owl:Class ;
                     rdfs:subClassOf :EvaluationCriterion ;
                     rdfs:isDefinedBy "Encompasses criteria directly affecting how an information fusion system transforms its input data into knowledge. It can also be called as process or inference criteria, as it deals with how the uncertainty model performs operations with information." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Relational
-:Relational rdf:type owl:Class ;
+:Relational a owl:Class ;
             rdfs:subClassOf :Expressiveness ;
             rdfs:isDefinedBy """[NOT REVIEWED as of GM55]
 Ability to represent uncertainty about domains with relational structure, e.g.,   attribute value uncertainty; reference uncertainty; type uncertainty; existence uncertainty.""" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#RelevanceToProblem
-:RelevanceToProblem rdf:type owl:Class ;
+:RelevanceToProblem a owl:Class ;
                     rdfs:subClassOf :InformationCriterion ;
                     rdfs:isDefinedBy "Measure the degree to which an evaluation subject has direct bearing on the objectives of the fusion process. " .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Reliability
-:Reliability rdf:type owl:Class ;
+:Reliability a owl:Class ;
              rdfs:subClassOf :SourceCriterion ;
              rdfs:isDefinedBy "TODO"@en ;
              owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#RepresentationCriterion
-:RepresentationCriterion rdf:type owl:Class ;
+:RepresentationCriterion a owl:Class ;
                          rdfs:subClassOf :EvaluationCriterion ;
                          rdfs:isDefinedBy "Encompasses criteria related to how uncertainty is characterized, captured and stored in a manner that can be processed by the fusion system. " .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Reputation
-:Reputation rdf:type owl:Class ;
+:Reputation a owl:Class ;
             rdfs:subClassOf :SourceCriterion ;
             rdfs:isDefinedBy "TODO"@en ;
             owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#RoughSets
-:RoughSets rdf:type owl:Class ;
+:RoughSets a owl:Class ;
            rdfs:subClassOf :UncertaintyTheory .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#STANAG2511
-:STANAG2511 rdf:type owl:Class ;
+:STANAG2511 a owl:Class ;
             rdfs:subClassOf :EvaluationMeasure ;
             owl:deprecated "true"^^xsd:boolean .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#STANAG2511Credibility
-:STANAG2511Credibility rdf:type owl:Class ;
+:STANAG2511Credibility a owl:Class ;
                        rdfs:subClassOf :STANAG2511 ;
                        owl:deprecated "true"^^xsd:boolean .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#STANAG2511Reliability
-:STANAG2511Reliability rdf:type owl:Class ;
+:STANAG2511Reliability a owl:Class ;
                        rdfs:subClassOf :STANAG2511 ;
                        owl:deprecated "true"^^xsd:boolean .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Scalability
-:Scalability rdf:type owl:Class ;
+:Scalability a owl:Class ;
              rdfs:subClassOf :ReasoningCriterion ;
              rdfs:isDefinedBy "Measure of the ability to handle a growing amount of work in a capable manner or its ability to be enlarged to accommodate that growth." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SelfConfidence
-:SelfConfidence rdf:type owl:Class ;
+:SelfConfidence a owl:Class ;
                 rdfs:subClassOf :Credibility ,
                                 :SourceCriterion ;
                 rdfs:isDefinedBy "Measure of the evaluation subject's assessment of its own credibility." ;
@@ -720,20 +720,20 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SensorMeasurement
-:SensorMeasurement rdf:type owl:Class ;
+:SensorMeasurement a owl:Class ;
                    rdfs:subClassOf :SingularEvidence ;
                    rdfs:isDefinedBy "TODO"@en ;
                    owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Simplicity
-:Simplicity rdf:type owl:Class ;
+:Simplicity a owl:Class ;
             rdfs:subClassOf :RepresentationCriterion ;
             rdfs:isDefinedBy "Assesses the information system's ability to execute common operations without requiring deep knowledge about its inner details. " .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SingularEvidence
-:SingularEvidence rdf:type owl:Class ;
+:SingularEvidence a owl:Class ;
                   rdfs:subClassOf :Information ;
                   rdfs:isDefinedBy "TODO"@en ;
                   rdfs:seeAlso "TODO: ref (ChatGPT paper)" ;
@@ -741,7 +741,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Soudness
-:Soudness rdf:type owl:Class ;
+:Soudness a owl:Class ;
           rdfs:subClassOf :ReasoningCriterion ;
           rdfs:comment "Changed name in version 4.0.0: from \"Correctness\" to \"Soundness\"."@en ;
           rdfs:isDefinedBy "The quality of being based on valid reason or good judgement."@en ;
@@ -750,75 +750,75 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Source
-:Source rdf:type owl:Class ;
+:Source a owl:Class ;
         rdfs:comment "A source is the origin of the information."@en .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#SourceCriterion
-:SourceCriterion rdf:type owl:Class ;
+:SourceCriterion a owl:Class ;
                  rdfs:subClassOf :EvaluationCriterion ;
                  rdfs:isDefinedBy "Any feature of the source which will affect the quality of the information provided by the source."@en ;
                  owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#StatisticalModel
-:StatisticalModel rdf:type owl:Class ;
+:StatisticalModel a owl:Class ;
                   rdfs:subClassOf :GenericKnowledge ;
                   rdfs:isDefinedBy "TODO"@en ;
                   owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Subjective
-:Subjective rdf:type owl:Class ;
+:Subjective a owl:Class ;
             rdfs:subClassOf :UncertaintyDerivation .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Testimony
-:Testimony rdf:type owl:Class ;
+:Testimony a owl:Class ;
            rdfs:subClassOf :SingularEvidence ;
            rdfs:isDefinedBy "TODO"@en ;
            owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Throughput
-:Throughput rdf:type owl:Class ;
+:Throughput a owl:Class ;
             rdfs:subClassOf :PerformanceCriterion ;
             rdfs:isDefinedBy "Measure of the average (and (possibly peak) rate of conversion of inputs to outputs." ;
             owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Timeliness
-:Timeliness rdf:type owl:Class ;
+:Timeliness a owl:Class ;
             rdfs:subClassOf :PerformanceCriterion ;
             rdfs:isDefinedBy "Measure of the ability to produce results within a required timeframe." ;
             owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Traceability
-:Traceability rdf:type owl:Class ;
+:Traceability a owl:Class ;
               rdfs:subClassOf :InformationHandlingCriterion ;
               rdfs:isDefinedBy "Measure of the ability of a fusion system to provide an accurate and unbroken historical record of its inputs and the chain of operations that led to its conclusions." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Transparency
-:Transparency rdf:type owl:Class ;
+:Transparency a owl:Class ;
               rdfs:subClassOf :SourceCriterion ;
               rdfs:isDefinedBy "TODO" ;
               owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Trust
-:Trust rdf:type owl:Class ;
+:Trust a owl:Class ;
        rdfs:isDefinedBy "TODO: placeholder to import trust ontologies" ;
        owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#TypeOfScale
-:TypeOfScale rdf:type owl:Class .
+:TypeOfScale a owl:Class .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertainEvidence
-:UncertainEvidence rdf:type owl:Class ;
+:UncertainEvidence a owl:Class ;
                    rdfs:subClassOf :InformationCriterion ;
                    rdfs:comment "Moved as a subclass of InformationCriterion in version 4.0.0." ;
                    rdfs:isDefinedBy "TODO" ;
@@ -826,13 +826,13 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyDerivation
-:UncertaintyDerivation rdf:type owl:Class ;
+:UncertaintyDerivation a owl:Class ;
                        rdfs:comment "Uncertainty derivation refers to the way it can be assessed. That is, how the uncertainty metrics can be derived."@en ;
                        rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyModel
-:UncertaintyModel rdf:type owl:Class ;
+:UncertaintyModel a owl:Class ;
                   rdfs:comment "Renamed from \"UncertaintyFunction\" in version 4.0.0." ;
                   rdfs:isDefinedBy """TODO:
 - a probability function
@@ -841,33 +841,33 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyNature
-:UncertaintyNature rdf:type owl:Class ;
+:UncertaintyNature a owl:Class ;
                    rdfs:comment "This captures the information about the nature of the uncertainty, i.e., whether the uncertainty is inherent in the phenomenon expressed by the sentence, or it is the result of lack of knowledge of the agent."@en ;
                    rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyReasoning
-:UncertaintyReasoning rdf:type owl:Class ;
+:UncertaintyReasoning a owl:Class ;
                       rdfs:isDefinedBy "TODO" ;
                       owl:versionInfo "4.0.0" .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyRepresentation
-:UncertaintyRepresentation rdf:type owl:Class .
+:UncertaintyRepresentation a owl:Class .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintySupport
-:UncertaintySupport rdf:type owl:Class ;
+:UncertaintySupport a owl:Class ;
                     rdfs:isDefinedBy "TODO: what you are certain about." .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyTheory
-:UncertaintyTheory rdf:type owl:Class ;
+:UncertaintyTheory a owl:Class ;
                    rdfs:isDefinedBy "http://www.w3.org/2005/Incubator/urw3/XGR-urw3-20080331/#uncertaintyontology"^^xsd:anyURI .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UncertaintyType
-:UncertaintyType rdf:type owl:Class ;
+:UncertaintyType a owl:Class ;
                  rdfs:comment "Uncertainty Type is a concept that focuses on underlying characteristics of the information that make it uncertain. "@en ,
                               """For the purposes of this ontology, Uncertainty type is equivalent to:
 - type of imperfection""" ;
@@ -875,12 +875,12 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#UnreliableEvidence
-:UnreliableEvidence rdf:type owl:Class ;
+:UnreliableEvidence a owl:Class ;
                     rdfs:subClassOf :UncertainEvidence .
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#Veracity
-:Veracity rdf:type owl:Class ;
+:Veracity a owl:Class ;
           rdfs:subClassOf :SourceCriterion ;
           rdfs:isDefinedBy "Measure of the extent to which a source reports what it assesses to be the case." ;
           owl:incompatibleWith 4 ;
@@ -888,7 +888,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 
 
 ###  http://eturwg.c4i.gmu.edu/files/ontologies/URREF#WeightOfInformation
-:WeightOfInformation rdf:type owl:Class ;
+:WeightOfInformation a owl:Class ;
                      rdfs:subClassOf :InformationCriterion ;
                      rdfs:comment "Renamed from \"WeightOfEvidence\" in version 4.0.0."@en ;
                      rdfs:isDefinedBy "Measure of the degree of impact of an evaluation subject on the result of fusion. " ;
@@ -900,7 +900,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 #    General axioms
 #################################################################
 
-[ rdf:type owl:AllDisjointClasses ;
+[ a owl:AllDisjointClasses ;
   owl:members ( :BeliefFunctions
                 :FuzzySets
                 :Probability
@@ -910,7 +910,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 ] .
 
 
-[ rdf:type owl:AllDisjointClasses ;
+[ a owl:AllDisjointClasses ;
   owl:members ( :Credibility
                 :RelevanceToProblem
                 :WeightOfInformation
@@ -918,7 +918,7 @@ Ability to represent uncertainty about domains with relational structure, e.g., 
 ] .
 
 
-[ rdf:type owl:AllDisjointClasses ;
+[ a owl:AllDisjointClasses ;
   owl:members ( :InformationCriterion
                 :InformationHandlingCriterion
                 :ReasoningCriterion


### PR DESCRIPTION
This fixes metadata, and should not be changing the semantics of any term.

However, commit 65bc2f3eb32585684ba87f53c1a27e14b64ad5bc is a change breaking backward compatibility (regarding the distribution of the ontology), albeit a necessary one, IMHO.

Non-breaking changes:
- Fixes remaining versions mistakes.
- Remove the old owl-ontologies IRI.
- Use direct domain/ranges.
- Make all terms sub[Term]Of root terms.
- Use `a` instead of `rdf:type` (a Turtle feature).
- Adds `rdfs:label` to all terms.